### PR TITLE
Support thin wrapper workflows in check_workflows hook and convert is…

### DIFF
--- a/.github/workflows/issue.yml
+++ b/.github/workflows/issue.yml
@@ -1,23 +1,7 @@
 name: Auto-label PDK issues
 
 on:
-  issues:
-    types:
-      - opened
-      - edited
-      - deleted
-      - pinned
-      - unpinned
-      - closed
-      - reopened
-      - assigned
-      - unassigned
-      - unlabeled
-      - locked
-      - unlocked
-      - transferred
-      - milestoned
-      - demilestoned
+  workflow_call:
 
 jobs:
   add-label:


### PR DESCRIPTION
…sue.yml to reusable workflow

check_workflows.py now recognizes job-level `uses:` calls referencing pdk-ci-workflow's test_code.yml as satisfying both pre-commit and test job requirements. This is needed for PDK repos adopting thin wrapper workflows instead of inline CI definitions.

issue.yml is converted from a direct-trigger workflow to a workflow_call reusable workflow, enabling PDK repos to use thin wrappers for issue auto-labeling.