### PR TITLE
Fix check-no-raw-layers false positives on center/size/offsets kwargs

### DIFF
--- a/hooks/check_no_raw_layers.py
+++ b/hooks/check_no_raw_layers.py
@@ -10,6 +10,27 @@ from hooks._utils import CheckResult, find_cell_files, find_package_dir, parse_f
 
 LAYER_SOURCE_FILES = {"tech.py", "layers.py", "config.py"}
 
+# Keyword argument names that carry layer specs — (int, int) tuples here are raw layers
+_LAYER_KWARG_NAMES: frozenset[str] = frozenset(
+    {
+        "layer",
+        "layers",
+        "layer_slab",
+        "layer_pin",
+        "layer_label",
+        "layer_heater",
+        "layer_trench",
+        "layer_port",
+        "layer_metal",
+        "layer_via",
+        "layers_via_stack1",
+        "layers_via_stack2",
+        "bbox_layers",
+        "cladding_layers",
+        "label_layer",
+    }
+)
+
 
 class RawLayerTupleFinder(ast.NodeVisitor):
     """Find (int, int) tuples used as layer arguments in cell code."""
@@ -19,6 +40,10 @@ class RawLayerTupleFinder(ast.NodeVisitor):
         self.result = result
         self._in_default = False
         self._in_class_body = False
+        # Current keyword argument name, or None when not inside a keyword argument.
+        # Distinguishes layer kwargs (layer=, layers=, bbox_layers=, …) from
+        # non-layer kwargs (center=, size=, offsets=, …).
+        self._kwarg_name: str | None = None
 
     def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
         # Check parameter defaults — these are allowed (LayerSpec defaults)
@@ -39,18 +64,43 @@ class RawLayerTupleFinder(ast.NodeVisitor):
         self.generic_visit(node)
         self._in_class_body = old
 
+    def visit_Call(self, node: ast.Call) -> None:
+        # Visit positional args with current kwarg context unchanged
+        for arg in node.args:
+            self.visit(arg)
+
+        # Visit each keyword arg, tracking the kwarg name so visit_Tuple can
+        # distinguish layer kwargs from non-layer kwargs (size=, center=, …).
+        for kw in node.keywords:
+            old = self._kwarg_name
+            self._kwarg_name = kw.arg  # None for **kwargs unpacking
+            self.visit(kw.value)
+            self._kwarg_name = old
+
     def visit_Tuple(self, node: ast.Tuple) -> None:
         if self._in_default or self._in_class_body:
             self.generic_visit(node)
             return
 
-        if self._is_layer_tuple(node):
+        if self._is_layer_tuple(node) and self._is_layer_context():
             a, b = node.elts[0].value, node.elts[1].value  # type: ignore[union-attr]
             self.result.error(
                 f"{self.filepath}:{node.lineno} raw layer tuple ({a}, {b}) — "
                 f"use LAYER.XXX constant instead"
             )
         self.generic_visit(node)
+
+    def _is_layer_context(self) -> bool:
+        """Return True if the current kwarg context looks like a layer argument."""
+        if self._kwarg_name is None:
+            # Not inside a keyword argument at all — flag conservatively.
+            return True
+        kwarg = self._kwarg_name
+        return (
+            kwarg in _LAYER_KWARG_NAMES
+            or kwarg.endswith("_layer")
+            or kwarg.endswith("_layers")
+        )
 
     @staticmethod
     def _is_layer_tuple(node: ast.Tuple) -> bool:


### PR DESCRIPTION
## Summary
- The hook was flagging any `(int, int)` tuple in function bodies as a raw layer
- This caused false positives for coordinates (`center=(0, 0)`), sizes (`size=(150, 140)`), and offsets (`offsets=(0, 5)`)
- Now tracks keyword argument name during AST traversal — only flags tuples in layer-named kwargs (`layer=`, `layers=`, `bbox_layers=`, etc.) or outside any kwarg context

## Test plan
- [ ] Verify `center=(0, 0)` is no longer flagged in ph18 die.py and fixed.py
- [ ] Verify `size=(150, 140)` is no longer flagged in ph18 mzm.py
- [ ] Verify `layers=[(198, 0)]` (genuine raw layer) is still flagged

🤖 Generated with [Claude Code](https://claude.com/claude-code)