### PR TITLE
Add workflow_call trigger to release-drafter

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
     types: [edited, opened, reopened, synchronize, unlabeled, labeled]
   workflow_dispatch:
+  workflow_call:
 permissions:
   contents: read
 jobs:


### PR DESCRIPTION
## Summary
- Adds `workflow_call` trigger to the release-drafter workflow so it can be used as a reusable workflow from other repos (e.g. via `uses: doplaydo/pdk-ci-workflow/.github/workflows/release-drafter.yml@main`)

## Context
Without `on.workflow_call`, GitHub Actions rejects calls to this workflow with:
> workflow is not reusable as it is missing a `on.workflow_call` trigger