### PR TITLE
Update GitHub App secret names to org-level GF_DEV_BOT secrets

### DIFF
--- a/.github/workflows/push-compliance.yml
+++ b/.github/workflows/push-compliance.yml
@@ -50,8 +50,8 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v2
         with:
-          app-id: ${{ secrets.GH_APP_ID }}
-          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.GF_DEV_BOT_GH_APP_ID }}
+          private-key: ${{ secrets.GF_DEV_BOT_GH_APP_PRIVATE_KEY }}
           owner: ${{ steps.parse.outputs.owner }}
           repositories: ${{ steps.parse.outputs.repo }}
 

--- a/README.md
+++ b/README.md
@@ -381,8 +381,8 @@ For PDK repositories:
 - `ANTHROPIC_API_KEY` - For Claude code reviews (`claude-pr-review.yml`)
 
 For this repository (push-compliance):
-- `GH_APP_ID` - GitHub App ID for cross-repo PRs
-- `GH_APP_PRIVATE_KEY` - GitHub App private key for cross-repo PRs
+- `GF_DEV_BOT_GH_APP_ID` - GitHub App ID for cross-repo PRs
+- `GF_DEV_BOT_GH_APP_PRIVATE_KEY` - GitHub App private key for cross-repo PRs
 
 ### GitHub Pages (for documentation)
 Enable GitHub Pages in your repository settings:


### PR DESCRIPTION
## Summary
- Renamed `GH_APP_ID` → `GF_DEV_BOT_GH_APP_ID` and `GH_APP_PRIVATE_KEY` → `GF_DEV_BOT_GH_APP_PRIVATE_KEY` in the push-compliance workflow and README
- Removed duplicated `GH_APP_ID` and `GH_PRIVATE_KEY` organization-level secrets

Relates to https://github.com/doplaydo/infra/issues/565

## Test plan
- [ ] Verify the org secrets `GF_DEV_BOT_GH_APP_ID` and `GF_DEV_BOT_GH_APP_PRIVATE_KEY` are configured
- [ ] Trigger the push-compliance workflow and confirm it authenticates successfully