### PR TITLE
register doplaydo/ant in pdks.yml

### DIFF
--- a/pdks.yml
+++ b/pdks.yml
@@ -3,6 +3,7 @@
 # iterates over this list to open sync PRs on every commit to main.
 pdks:
   - doplaydo/pdk-ci-demo
+  - doplaydo/ant
   # Add real PDK repos here as they're onboarded, e.g.:
   # - gdsfactory/cspdk
   # - gdsfactory/ubcpdk


### PR DESCRIPTION
Adds `doplaydo/ant` to the push-compliance registry as the first real PDK being onboarded to the centralized CI workflow scheme (see doplaydo/ant#20).

Once merged, the `push-compliance` workflow will automatically open a sync PR on `doplaydo/ant` applying all templates.