### PR TITLE
Add centralized build-wheels and release reusable workflows

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -1,0 +1,62 @@
+name: Build Wheels
+
+on:
+  workflow_call:
+    inputs:
+      pre_build_command:
+        type: string
+        default: 'make rm-samples'
+        description: 'Command to run before building wheels (empty string to skip)'
+      use_just:
+        type: boolean
+        default: false
+        description: 'Install just command runner via extractions/setup-just'
+      cibw_environment_macos:
+        type: string
+        default: ''
+        description: 'Extra CIBW_ENVIRONMENT_MACOS value (e.g. MACOSX_DEPLOYMENT_TARGET=14.0)'
+      windows_arm:
+        type: boolean
+        default: true
+        description: 'Include ARM64 in Windows wheel builds'
+
+jobs:
+  build-wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            cibw_archs: 'native'
+          - os: ubuntu-arm-2core
+            cibw_archs: 'aarch64'
+          - os: windows-latest
+            cibw_archs: >-
+              ${{ inputs.windows_arm && 'native ARM64' || 'native' }}
+          - os: macos-latest
+            cibw_archs: 'native arm64'
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - if: inputs.use_just
+        uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
+
+      - name: Pre-build
+        if: inputs.pre_build_command != ''
+        run: ${{ inputs.pre_build_command }}
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@faf86a6ed7efa889faf6996aa23820831055001a # v3.3.1
+        env:
+          CIBW_ARCHS: ${{ matrix.cibw_archs }}
+          CIBW_SKIP: '*-musllinux* pp*'
+          CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
+          CIBW_MANYLINUX_AARCH64_IMAGE: manylinux_2_28
+          CIBW_ENVIRONMENT_MACOS: ${{ inputs.cibw_environment_macos }}
+
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v7
+        with:
+          name: wheels-${{ matrix.os }}
+          path: ./wheelhouse/*.whl

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,441 @@
+name: Release
+
+on:
+  workflow_call:
+    inputs:
+      # ── Build configuration ──────────────────────────────────────────
+      pre_build_command:
+        type: string
+        default: 'make rm-samples'
+        description: 'Command to run before building wheels (empty string to skip)'
+      use_just:
+        type: boolean
+        default: false
+        description: 'Install just command runner via extractions/setup-just'
+      cibw_environment_macos:
+        type: string
+        default: ''
+        description: 'Extra CIBW_ENVIRONMENT_MACOS value (e.g. MACOSX_DEPLOYMENT_TARGET=14.0)'
+      windows_arm:
+        type: boolean
+        default: true
+        description: 'Include ARM64 in Windows wheel builds'
+      checkout_submodules:
+        type: string
+        default: 'false'
+        description: 'Submodule checkout mode (false, true, or recursive)'
+
+      # ── Release target ───────────────────────────────────────────────
+      # Pick ONE of: devpi, pypi, pypi-trusted, none
+      release_target:
+        type: string
+        default: 'devpi'
+        description: 'Where to publish: devpi | pypi | pypi-trusted | none'
+
+      # ── DevPI configuration ─────────────────────────────────────────
+      devpi_prod_orgs:
+        type: string
+        default: ''
+        description: 'Newline-delimited org UUIDs for prod DevPI uploads'
+      devpi_dev_orgs:
+        type: string
+        default: ''
+        description: 'Newline-delimited org UUIDs for dev DevPI uploads'
+
+      # ── PyPI configuration ──────────────────────────────────────────
+      pypi_build_command:
+        type: string
+        default: 'make build'
+        description: 'Build command for PyPI sdist (e.g. make modules build)'
+      pypi_use_docker:
+        type: boolean
+        default: false
+        description: 'Run PyPI build inside ghcr.io/gdsfactory/gdsfactory:main container'
+
+      # ── GitHub Release configuration ────────────────────────────────
+      upload_uv_lock:
+        type: boolean
+        default: false
+        description: 'Upload uv.lock to GitHub release assets'
+      upload_requirements_txt:
+        type: boolean
+        default: false
+        description: 'Generate and upload requirements.txt to GitHub release assets'
+      ligentec_release_style:
+        type: boolean
+        default: false
+        description: 'Use draft-delete-recreate release pattern instead of editing existing draft'
+
+      # ── PDF documentation ───────────────────────────────────────────
+      build_pdf:
+        type: boolean
+        default: false
+        description: 'Build PDF documentation via LaTeX'
+      pdf_filename_prefix:
+        type: string
+        default: 'docs'
+        description: 'Prefix for PDF filename (produces {prefix}-{tag}.pdf)'
+      pdf_install_command:
+        type: string
+        default: 'make dev'
+        description: 'Command to install docs dependencies'
+      pdf_build_command:
+        type: string
+        default: 'make docs-pdf'
+        description: 'Command to build PDF documentation'
+
+    secrets:
+      DEVPI_USERNAME:
+        required: false
+      DEVPI_PASSWORD:
+        required: false
+      DEVPI_USERNAME_DEV:
+        required: false
+      DEVPI_PASSWORD_DEV:
+        required: false
+      PYPI_USERNAME:
+        required: false
+      PYPI_PASSWORD:
+        required: false
+      GFP_API_KEY:
+        required: false
+      SIMCLOUD_APIKEY:
+        required: false
+
+env:
+  GFP_API_KEY: ${{ secrets.GFP_API_KEY }}
+  SIMCLOUD_APIKEY: ${{ secrets.SIMCLOUD_APIKEY }}
+
+jobs:
+  # ════════════════════════════════════════════════════════════════════
+  # Build wheels (DevPI releases only)
+  # ════════════════════════════════════════════════════════════════════
+  build-wheels:
+    if: inputs.release_target == 'devpi'
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            cibw_archs: 'native'
+          - os: ubuntu-arm-2core
+            cibw_archs: 'aarch64'
+          - os: windows-latest
+            cibw_archs: >-
+              ${{ inputs.windows_arm && 'native ARM64' || 'native' }}
+          - os: macos-latest
+            cibw_archs: 'native arm64'
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          submodules: ${{ inputs.checkout_submodules }}
+
+      - if: inputs.use_just
+        uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
+
+      - name: Pre-build
+        if: inputs.pre_build_command != ''
+        run: ${{ inputs.pre_build_command }}
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@faf86a6ed7efa889faf6996aa23820831055001a # v3.3.1
+        env:
+          CIBW_ARCHS: ${{ matrix.cibw_archs }}
+          CIBW_SKIP: '*-musllinux* pp*'
+          CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
+          CIBW_MANYLINUX_AARCH64_IMAGE: manylinux_2_28
+          CIBW_ENVIRONMENT_MACOS: ${{ inputs.cibw_environment_macos }}
+
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v7
+        with:
+          name: wheels-${{ matrix.os }}
+          path: ./wheelhouse/*.whl
+
+  # ════════════════════════════════════════════════════════════════════
+  # Build PDF documentation (optional)
+  # ════════════════════════════════════════════════════════════════════
+  build-doc-pdf:
+    if: inputs.build_pdf
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          submodules: ${{ inputs.checkout_submodules }}
+
+      - if: inputs.use_just
+        uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
+
+      - name: Pre-build
+        if: inputs.pre_build_command != ''
+        run: ${{ inputs.pre_build_command }}
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: '3.12'
+
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+
+      - name: Install dependencies
+        run: |
+          ${{ inputs.pdf_install_command }}
+          sudo apt-get update
+          sudo apt-get install -y texlive-latex-extra \
+                     texlive-fonts-extra \
+                     texlive-xetex latexmk \
+                     xindy
+
+      - name: Build PDF
+        run: |
+          ${{ inputs.pdf_build_command }}
+          mv docs.pdf ${{ inputs.pdf_filename_prefix }}-${{ github.ref_name }}.pdf
+
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v7
+        with:
+          name: docs
+          path: ./${{ inputs.pdf_filename_prefix }}-${{ github.ref_name }}.pdf
+
+  # ════════════════════════════════════════════════════════════════════
+  # Release to DevPI (dev + prod registries)
+  # ════════════════════════════════════════════════════════════════════
+  release-devpi:
+    if: inputs.release_target == 'devpi'
+    needs: build-wheels
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: '3.12'
+
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v8
+        with:
+          pattern: wheels-*
+          path: dist
+          merge-multiple: true
+
+      - name: Release to DevPI dev
+        if: inputs.devpi_dev_orgs != ''
+        env:
+          TWINE_USERNAME: ${{ secrets.DEVPI_USERNAME_DEV }}
+          TWINE_PASSWORD: ${{ secrets.DEVPI_PASSWORD_DEV }}
+        run: |
+          pip install twine
+          while IFS= read -r line; do
+            # Skip blank lines and comments
+            [[ -z "$line" || "$line" =~ ^[[:space:]]*# ]] && continue
+            repo_id=$(echo "$line" | awk '{print $1}')
+            echo "Uploading to dev DevPI org: $repo_id"
+            twine upload --repository-url "https://dev.gdsfactory.com/api/upload-packages/$repo_id" dist/*
+          done <<< "${{ inputs.devpi_dev_orgs }}"
+
+      - name: Release to DevPI prod
+        if: inputs.devpi_prod_orgs != ''
+        env:
+          TWINE_USERNAME: ${{ secrets.DEVPI_USERNAME }}
+          TWINE_PASSWORD: ${{ secrets.DEVPI_PASSWORD }}
+        run: |
+          pip install twine
+          while IFS= read -r line; do
+            # Skip blank lines and comments
+            [[ -z "$line" || "$line" =~ ^[[:space:]]*# ]] && continue
+            repo_id=$(echo "$line" | awk '{print $1}')
+            echo "Uploading to prod DevPI org: $repo_id"
+            twine upload --repository-url "https://prod.gdsfactory.com/api/upload-packages/$repo_id" dist/*
+          done <<< "${{ inputs.devpi_prod_orgs }}"
+
+  # ════════════════════════════════════════════════════════════════════
+  # Release to PyPI (standard twine upload)
+  # ════════════════════════════════════════════════════════════════════
+  release-pypi:
+    if: inputs.release_target == 'pypi' && !inputs.pypi_use_docker
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          submodules: ${{ inputs.checkout_submodules }}
+
+      - if: inputs.use_just
+        uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
+
+      - name: Pre-build
+        if: inputs.pre_build_command != ''
+        run: ${{ inputs.pre_build_command }}
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: '3.12'
+
+      - name: Build and publish
+        env:
+          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        run: |
+          python -m pip install --upgrade pip
+          pip install setuptools wheel twine
+          ${{ inputs.pypi_build_command }}
+          twine upload dist/*
+
+  # ════════════════════════════════════════════════════════════════════
+  # Release to PyPI (Docker container variant)
+  # ════════════════════════════════════════════════════════════════════
+  release-pypi-docker:
+    if: inputs.release_target == 'pypi' && inputs.pypi_use_docker
+    runs-on: ubuntu-latest
+    container: ghcr.io/gdsfactory/gdsfactory:main
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          submodules: ${{ inputs.checkout_submodules }}
+
+      - name: Pre-build
+        if: inputs.pre_build_command != ''
+        run: ${{ inputs.pre_build_command }}
+
+      - name: Build and publish
+        env:
+          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        run: |
+          python -m pip install --upgrade pip
+          pip install setuptools wheel twine
+          ${{ inputs.pypi_build_command }}
+          twine upload dist/*
+
+  # ════════════════════════════════════════════════════════════════════
+  # Release to PyPI (trusted publisher / OIDC)
+  # ════════════════════════════════════════════════════════════════════
+  release-pypi-trusted:
+    if: inputs.release_target == 'pypi-trusted'
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v8
+        with:
+          name: dist
+          path: dist
+
+      - uses: pypa/gh-action-pypi-publish@76f52bc884231f62b54f72e44af3222aff7e3a45 # release/v1
+        with:
+          user: ${{ secrets.PYPI_USERNAME }}
+          password: ${{ secrets.PYPI_PASSWORD }}
+          packages-dir: dist
+
+  # ════════════════════════════════════════════════════════════════════
+  # Publish GitHub Release (mark draft as non-draft, upload lock files)
+  # ════════════════════════════════════════════════════════════════════
+  release-environment:
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags') && !inputs.ligentec_release_style
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          submodules: ${{ inputs.checkout_submodules }}
+
+      - name: Publish Release
+        run: |
+          gh release edit ${{ github.ref_name }} --draft=false
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload uv.lock
+        if: inputs.upload_uv_lock
+        run: |
+          if [ -f uv.lock ]; then
+            gh release upload ${{ github.ref_name }} uv.lock --clobber
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload requirements.txt
+        if: inputs.upload_requirements_txt
+        run: |
+          pip install .
+          pip freeze > requirements.txt
+          gh release upload ${{ github.ref_name }} requirements.txt --clobber
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # ════════════════════════════════════════════════════════════════════
+  # Upload artifacts to GitHub Release
+  # ════════════════════════════════════════════════════════════════════
+  release-gh:
+    if: >-
+      github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+      && inputs.release_target == 'devpi'
+      && !inputs.ligentec_release_style
+    needs:
+      - release-devpi
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v8
+        with:
+          pattern: wheels-*
+          path: dist
+          merge-multiple: true
+
+      - name: Download PDF
+        if: inputs.build_pdf
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v8
+        with:
+          name: docs
+          path: dist
+
+      - name: Upload to GitHub Release
+        uses: softprops/action-gh-release@da05d552573ad5aba039eaac05058a918a7bf631 # v2
+        with:
+          files: dist/*
+
+  # ════════════════════════════════════════════════════════════════════
+  # Ligentec-style release (draft-delete-recreate + artifact upload)
+  # ════════════════════════════════════════════════════════════════════
+  release-gh-ligentec:
+    if: >-
+      github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+      && inputs.ligentec_release_style
+    needs:
+      - release-devpi
+      - build-doc-pdf
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v8
+        with:
+          pattern: wheels-*
+          path: dist
+          merge-multiple: true
+
+      - name: Download PDF
+        if: inputs.build_pdf
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v8
+        with:
+          name: docs
+          path: dist
+
+      - name: Create or convert release from draft
+        run: |
+          new_version="$(echo '${{ github.ref_name }}' | sed 's/^v//g')"
+          if gh release list | grep Draft; then
+            old_version="$(gh release list | grep Draft | head -1 | cut -f1 | sed 's/^[ ]*v//g')"
+            body=$(gh release view "v$old_version" --json body -q ".body" | sed "s/\.\.\.v$old_version/...v$new_version/g")
+            echo "$body"
+            gh release delete "v$old_version" --yes
+            gh release create "v$new_version" --title "v$new_version" --notes "$body"
+          else
+            gh release create "v$new_version" --title "v$new_version"
+          fi
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Upload artifacts to release
+        uses: softprops/action-gh-release@da05d552573ad5aba039eaac05058a918a7bf631 # v2
+        with:
+          files: dist/*

--- a/templates/.github/workflows/build-wheels.yml
+++ b/templates/.github/workflows/build-wheels.yml
@@ -1,0 +1,7 @@
+name: Build Wheels
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    uses: doplaydo/pdk-ci-workflow/.github/workflows/build-wheels.yml@{{VERSION}}

--- a/templates/.github/workflows/release-devpi.yml
+++ b/templates/.github/workflows/release-devpi.yml
@@ -1,0 +1,27 @@
+name: PDK
+on:
+  push:
+    branches:
+      - release*
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+jobs:
+  release:
+    uses: doplaydo/pdk-ci-workflow/.github/workflows/release.yml@{{VERSION}}
+    with:
+      release_target: devpi
+      upload_uv_lock: true
+      devpi_dev_orgs: |
+        # DoPlayDo
+        3b166b0a-0737-4cfc-ac9f-58cfd2562e5d
+      devpi_prod_orgs: |
+        # DoPlayDo
+        01660aaf-92f9-42a7-bd2d-0df7de79ce8b
+    secrets:
+      DEVPI_USERNAME: ${{ secrets.DEVPI_USERNAME }}
+      DEVPI_PASSWORD: ${{ secrets.DEVPI_PASSWORD }}
+      DEVPI_USERNAME_DEV: ${{ secrets.DEVPI_USERNAME_DEV }}
+      DEVPI_PASSWORD_DEV: ${{ secrets.DEVPI_PASSWORD_DEV }}
+      GFP_API_KEY: ${{ secrets.GFP_API_KEY }}

--- a/templates/.github/workflows/release-pypi.yml
+++ b/templates/.github/workflows/release-pypi.yml
@@ -1,0 +1,13 @@
+name: Release
+on:
+  push:
+    tags: "v*"
+
+jobs:
+  release:
+    uses: doplaydo/pdk-ci-workflow/.github/workflows/release.yml@{{VERSION}}
+    with:
+      release_target: pypi
+    secrets:
+      PYPI_USERNAME: ${{ secrets.PYPI_USERNAME }}
+      PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}


### PR DESCRIPTION
## Summary

Audited all 25+ PDK repositories and centralized the duplicated `release.yml` and `build-wheels.yml` CI workflows into two reusable `workflow_call` workflows.

- **`build-wheels.yml`** — Standalone cibuildwheel workflow for manual wheel builds
- **`release.yml`** — Full release pipeline orchestrator covering all three release patterns
- **3 caller templates** — Minimal callers for DevPI, PyPI, and standalone wheel builds

## Audit Findings

### build-wheels.yml (14 PDKs had this)
All nearly identical with cosmetic drift:
| Dimension | Current spread | Centralized |
|-----------|---------------|-------------|
| cibuildwheel | v3.0.0 – v3.3.1 | **v3.3.1** |
| actions/checkout | v4 – v6 | **v6** (SHA-pinned) |
| actions/upload-artifact | v4 – v7 | **v7** (SHA-pinned) |
| Pre-build | `make rm-samples` / `just rm-samples` / none | Configurable input |
| macOS env | Only tps45 needs `MACOSX_DEPLOYMENT_TARGET=14.0` | Configurable input |

### release.yml (25 PDKs) — Three patterns identified

**Pattern A: Simple PyPI** (6 PDKs: cspdk, ihp, gf180mcu, skywater130, ubc, etc.)
- Tag trigger → `make build` → twine upload to PyPI
- Some use Docker container for build environment

**Pattern B: Wheel + DevPI** (14 PDKs: amf, ant, aim-act, imec-isipp50, etc.)
- Branch/tag/dispatch trigger → cibuildwheel matrix → DevPI upload to per-PDK org UUID lists
- Optional: PDF docs, uv.lock upload, GitHub release with wheel artifacts
- DevPI org lists range from 1 to 14 UUIDs per PDK

**Pattern C: Auto-tag** (quantum-rf-pdk only)
- Push to main → parse version → create tag → build → PyPI
- **Not centralized** — too unique, should remain local

## Design Choices

### Parameterized inputs over separate workflows
Rather than creating one workflow per pattern, a single `release.yml` with `release_target` input (`devpi` | `pypi` | `pypi-trusted` | `none`) gates which jobs run via `if:` conditions. This avoids workflow sprawl while keeping each caller minimal.

### DevPI org UUIDs as newline-delimited strings
GitHub Actions `workflow_call` doesn't support array inputs. Org UUIDs are passed as multi-line strings, parsed with `while IFS= read -r`. Supports inline comments (`# OrgName`) and blank lines for readability.

### Two mutually exclusive PyPI jobs for Docker
The `container:` field in GitHub Actions must be static per job — it can't be conditionally omitted. Solution: `release-pypi` (no container) and `release-pypi-docker` (with container), gated by `pypi_use_docker` boolean.

### Inlined wheel-build in release.yml
GitHub Actions only allows one level of `workflow_call` nesting. The release workflow cannot call the standalone `build-wheels.yml`, so wheel-build logic is duplicated between the two files. The standalone `build-wheels.yml` exists for `workflow_dispatch` use cases outside releases.

### Ligentec release style as a flag
ligentec-an350/an800 use a unique draft-delete-recreate release pattern. Rather than keeping these workflows local, `ligentec_release_style: true` switches to a separate `release-gh-ligentec` job. This avoids maintaining two separate release workflow variants.

### SHA-pinned actions
Following the existing repo convention, all actions are SHA-pinned with version comments.

## Caller examples (what each PDK's workflow becomes)

**DevPI PDK (~25 lines replaces ~150):**
```yaml
jobs:
  release:
    uses: doplaydo/pdk-ci-workflow/.github/workflows/release.yml@v1
    with:
      release_target: devpi
      upload_uv_lock: true
      build_pdf: true
      pdf_filename_prefix: amf-gdsfactory
      devpi_dev_orgs: "3b166b0a-..."
      devpi_prod_orgs: |
        01660aaf-...
        ba5cb80e-...
    secrets:
      DEVPI_USERNAME: ${{ secrets.DEVPI_USERNAME }}
      DEVPI_PASSWORD: ${{ secrets.DEVPI_PASSWORD }}
```

**Simple PyPI PDK (~12 lines):**
```yaml
jobs:
  release:
    uses: doplaydo/pdk-ci-workflow/.github/workflows/release.yml@v1
    with:
      release_target: pypi
    secrets:
      PYPI_USERNAME: ${{ secrets.PYPI_USERNAME }}
      PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
```

## Limitations & Known Conflicts

1. **quantum-rf-pdk must stay local** — Its auto-tag-on-main-push pattern is fundamentally different
2. **aim-act variant workflows** (`release-apsuny.yml`, `release-rfs-sp-drp.yml`) have unique pre-build steps — keep local, can call shared `build-wheels.yml`
3. **Nesting restriction** — Wheel-build logic is duplicated between `build-wheels.yml` and `release.yml` due to GitHub's single-level nesting limit
4. **Matrix `if:` bug** — Several current PDKs have `if:` fields on matrix `include` entries (to skip ARM on non-tag pushes). These are actually no-ops in GitHub Actions. The centralized workflow always builds all platforms; callers that truly need conditional platforms can use separate `workflow_dispatch` triggers
5. **Version normalization** — All PDKs will jump to latest action versions (checkout v6, cibuildwheel v3.3.1). Test each migration individually

## Rollout Plan

1. Test with one simple PDK (cspdk) and one complex PDK (amf)
2. Migrate PDKs in batches, simplest first
3. Tag `v1` of this repo, pin all callers to `@v1`
4. Delete old inline workflow files from each PDK

## Test plan

- [ ] Trigger `workflow_dispatch` on `build-wheels.yml` to verify wheel artifacts
- [ ] Tag a test release on a simple PyPI PDK (cspdk) to verify full pipeline
- [ ] Tag a test release on a DevPI PDK (amf) to verify multi-org upload
- [ ] Verify PDF generation with `build_pdf: true` on a PDK that uses it
- [ ] Test Docker-based PyPI PDK (ihp) with `pypi_use_docker: true`
- [ ] Test ligentec release style on ligentec-an800

🤖 Generated with [Claude Code](https://claude.com/claude-code)