### PR TITLE
remove legacy requires-pytz hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This repository provides reusable automation tooling for Process Design Kit (PDK
 - Standardized testing, linting, and type checking across all PDKs
 - Automated documentation builds and deployments
 - AI-powered code reviews via Claude
-- 15 pre-commit hooks enforcing PDK structural compliance
+- 14 pre-commit hooks enforcing PDK structural compliance
 - Semantic versioning and automated release notes
 - Template files for onboarding new PDK repos
 
@@ -85,7 +85,6 @@ repos:
   - repo: https://github.com/doplaydo/pdk-ci-workflow
     rev: v1  # Use specific version tag
     hooks:
-      - id: requires-pytz
       - id: check-required-files
       - id: check-pyproject-sections
       - id: check-package-init
@@ -237,7 +236,6 @@ repos:
   - repo: https://github.com/doplaydo/pdk-ci-workflow
     rev: v1  # Use specific version tag
     hooks:
-      - id: requires-pytz
       - id: check-required-files
       - id: check-pyproject-sections
       # ... add hooks as needed
@@ -278,12 +276,11 @@ pre-commit install
 | `check-workflows` | `.github/workflows/` has test_code.yml with pre-commit and test jobs |
 | `check-precommit-config` | `.pre-commit-config.yaml` includes required hooks (trailing-whitespace, end-of-file-fixer, ruff, ruff-format) |
 
-#### Multi-band & Dependencies
+#### Multi-band
 
 | Hook ID | What it checks |
 |---------|---------------|
 | `check-multi-band` | For multi-band PDKs: consistent module sets per band, corresponding tests, shared layers |
-| `requires-pytz` | Ensures `pytz` is in `[project.dependencies]`; auto-injects if missing |
 
 ## Templates
 
@@ -293,7 +290,7 @@ Reference configuration files are provided in `templates/` for onboarding new PD
 
 | Template | Purpose |
 |----------|---------|
-| `.pre-commit-config.yaml` | Pre-commit hook config with all 15 PDK compliance hooks |
+| `.pre-commit-config.yaml` | Pre-commit hook config with all 14 PDK compliance hooks |
 | `.github/workflows/test_code.yml` | Thin wrapper calling reusable test workflow |
 | `.github/workflows/pages.yml` | Thin wrapper calling reusable docs workflow |
 | `.github/workflows/claude-pr-review.yml` | Thin wrapper for AI code review |

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -4,7 +4,7 @@ Pre-commit hook scripts for PDK template compliance. These are referenced by `.p
 
 Each hook is a self-contained Python script that validates some aspect of a PDK repository's structure and configuration. Hooks use **errors** for required items (fail the hook) and **warnings** for recommended items (print but pass).
 
-## Available Hooks (15)
+## Available Hooks (14)
 
 ### Project Structure
 
@@ -34,12 +34,11 @@ Each hook is a self-contained Python script that validates some aspect of a PDK 
 | `check-workflows` | `check_workflows.py` | `.github/workflows/` has test_code.yml (or test.yml) with pre-commit job and test job; recommends release.yml |
 | `check-precommit-config` | `check_precommit_config.py` | `.pre-commit-config.yaml` includes required hooks (end-of-file-fixer, trailing-whitespace, ruff, ruff-format) and recommended hooks (nbstripout, codespell) |
 
-### Multi-band & Dependencies
+### Multi-band
 
 | Hook ID | Source | What it checks |
 |---------|--------|---------------|
 | `check-multi-band` | `check_multi_band.py` | For multi-band PDKs (2+ band directories): consistent module sets per band (cells, tech, models), corresponding test files, shared layers at package root. Silently passes for single-band PDKs. |
-| `requires-pytz` | `check_requires_pytz.py` | Ensures `pytz` is in `[project.dependencies]` of pyproject.toml; auto-injects if missing |
 
 ## Shared Utilities (`_utils.py`)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,6 @@ dependencies = [
 ]
 
 [project.scripts]
-check_requires_pytz = "hooks.check_requires_pytz:check_pyproject"
 check_required_files = "hooks.check_required_files:main"
 check_pyproject_sections = "hooks.check_pyproject_sections:main"
 check_package_init = "hooks.check_package_init:main"

--- a/templates/.pre-commit-config.yaml
+++ b/templates/.pre-commit-config.yaml
@@ -3,9 +3,6 @@ repos:
   - repo: https://github.com/doplaydo/pdk-ci-workflow
     rev: "{{VERSION}}"
     hooks:
-      - id: requires-pytz
-        name: Ensure pytz in pyproject.toml
-        always_run: true
       - id: check-required-files
         always_run: true
       - id: check-pyproject-sections


### PR DESCRIPTION
## Summary
- Remove all references to the `requires-pytz` hook, which was a legacy dependency that is no longer needed (confirmed by Thomas)
- Removed from: `templates/.pre-commit-config.yaml`, `pyproject.toml` entry point, `README.md`, and `hooks/README.md`
- Updated hook counts from 15 to 14 in documentation

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)