### PR TITLE
fix drc workflow triggering in pdk-ci-workflow repo itself

### DIFF
--- a/.github/workflows/drc.yml
+++ b/.github/workflows/drc.yml
@@ -1,9 +1,9 @@
 name: DRC Check
 on:
-  workflow_dispatch:
-  push:
-    branches:
-      - main
+  workflow_call:
+    secrets:
+      GFP_API_KEY:
+        required: false
 env:
   GFP_API_KEY: ${{ secrets.GFP_API_KEY }}
 permissions:


### PR DESCRIPTION
The DRC check was configured with `push: main` and `workflow_dispatch` triggers, causing it to run within this repo itself. Like the other reusable workflows (e.g. `test_code.yml`), it should only run when called from other PDK repos via `workflow_call`.

Changes:
- Replace `workflow_dispatch` + `push: branches: main` with `workflow_call` (with `GFP_API_KEY` secret passthrough)