### PR TITLE
fix pages.yml: forward GFP_API_KEY and SIMCLOUD_APIKEY secrets

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,11 +1,19 @@
 name: build docs
 on:
   workflow_call:
+    secrets:
+      GFP_API_KEY:
+        required: false
+      SIMCLOUD_APIKEY:
+        required: false
 jobs:
   build-docs:
     if: github.event_name != 'pull_request' || github.event.pull_request.user.login != 'dependabot[bot]'
     runs-on: ubuntu-latest
     name: Sphinx docs to gh-pages
+    env:
+      GFP_API_KEY: ${{ secrets.GFP_API_KEY }}
+      SIMCLOUD_APIKEY: ${{ secrets.SIMCLOUD_APIKEY }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Set up Python


### PR DESCRIPTION
Reusable workflows do not inherit secrets from the caller unless explicitly declared under `on.workflow_call.secrets` and mapped to the job environment. Without this, `GFP_API_KEY` is empty at runtime, the PDK import triggers the license check, and the build dies with `LicenseError: Invalid GFP_API_KEY`.

**Root cause confirmed in:** doplaydo/qci#253, doplaydo/45SPCLO#55 — both migrated `pages.yml` to this centralized wrapper and started failing docs CI.

**Fix:** mirrors the pattern already used in `test_code.yml`.

Closes #24