### PR TITLE
fix: use make dev for docs build

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -24,7 +24,7 @@ jobs:
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
       - name: Install dependencies
         run: |
-          make install
+          make dev
       - name: make docs
         run: |
           make docs


### PR DESCRIPTION
## Summary
- Change `make install` to `make dev` in the pages workflow
- `make install` only installs `dev` extras, but docs builds need `jupyter-book` which is in the `docs` extras
- `make dev` installs both `dev` and `docs` extras

## Test plan
- [ ] Verify docs CI passes on downstream PDK repos after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)