### PR TITLE
Standardize workflow templates: secrets inherit, add missing drc/issue

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,16 +1,32 @@
 # Reusable Workflows
 
-Reusable workflows are complete, self-contained workflow definitions that live in `.github/workflows/` and are triggered via `workflow_call`. When another repo calls a reusable workflow, it's delegating an entire job — the reusable workflow controls everything: which runner it uses, what permissions it has, what steps run, and how secrets are handled. The calling repo just says "run this job for me" and optionally passes in some inputs. This is ideal when you want to enforce a standardised process across your org where individual teams shouldn't be tweaking the internals.
+Reusable workflows are complete, self-contained workflow definitions triggered via `workflow_call`. When a PDK repo calls a reusable workflow, it delegates the entire job — the workflow controls the runner, permissions, steps, and secret handling. The calling repo just says "run this job for me."
+
+PDK repos create thin wrapper workflows that call these using `secrets: inherit`. See `templates/.github/workflows/` for ready-to-copy wrappers.
 
 ## Workflows
 
-### Reusable (called by PDK repos)
+| Workflow | Jobs | Secrets Used | Description |
+|----------|------|-------------|-------------|
+| `test_code.yml` | pre-commit, test_code, test_gfp | `GFP_API_KEY` | Pre-commit (fetches canonical config), pytest, GFP validation |
+| `pages.yml` | build-docs, deploy-docs | `GFP_API_KEY`, `SIMCLOUD_APIKEY` | Sphinx docs build and GitHub Pages deployment |
+| `claude-pr-review.yml` | review | `ANTHROPIC_API_KEY` | AI code review via Claude Sonnet 4 on PRs |
+| `release-drafter.yml` | update_release_draft | `GITHUB_TOKEN` | Auto-drafted release notes with semantic versioning |
+| `drc.yml` | drc | `GFP_API_KEY` | Design Rule Check with badge generation |
+| `issue.yml` | add-label | `GITHUB_TOKEN` | Auto-labels issues with "pdk" tag |
 
-| Workflow | Trigger | Jobs | Required Secrets | Description |
-|----------|---------|------|-----------------|-------------|
-| `test_code.yml` | `workflow_call` | pre-commit, test_code, test_gfp | `GFP_API_KEY` | Linting (ruff), type checking (pyright), pytest, GFP platform validation |
-| `pages.yml` | `workflow_call` | build-docs, deploy-docs | None | Sphinx docs build via `make docs` and GitHub Pages deployment |
-| `claude-pr-review.yml` | `workflow_call` | claude-review | `ANTHROPIC_API_KEY` | AI code review via Claude Sonnet 4 on PRs and `@claude` mentions |
-| `release-drafter.yml` | `workflow_call` | update_release_draft | None | Auto-drafted release notes with semantic versioning based on PR labels |
+## Example Usage
 
-PDK repos create thin wrapper workflows that call these. See the main [README](../../README.md#reusable-workflows) for usage examples, or use the templates from `templates/.github/workflows/`.
+```yaml
+# .github/workflows/test_code.yml (in a PDK repo)
+name: Test code
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    uses: doplaydo/pdk-ci-workflow/.github/workflows/test_code.yml@main
+    secrets: inherit
+```

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -1,5 +1,9 @@
 name: Claude Auto Review
 on:
+  workflow_call:
+    secrets:
+      ANTHROPIC_API_KEY:
+        required: true
   pull_request:
     types: [opened, synchronize, reopened]
 permissions:

--- a/.github/workflows/issue.yml
+++ b/.github/workflows/issue.yml
@@ -1,5 +1,6 @@
 name: Auto-label PDK issues
 on:
+  workflow_call:
   issues:
     types:
       - opened

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ See [`hooks/README.md`](hooks/README.md) for detailed documentation.
 
 | Hook ID | What it checks |
 |---------|---------------|
-| `check-required-files` | README.md, LICENSE, Makefile, pyproject.toml, .pre-commit-config.yaml, tests/, workflows exist |
+| `check-required-files` | README.md, CHANGELOG.md, LICENSE, Makefile, pyproject.toml, .gitignore, .pre-commit-config.yaml, tests/, test workflow, release-drafter workflow |
 | `check-pyproject-sections` | Deep validation of pyproject.toml: build-system, project fields, ruff, codespell, pytest, tbump, mypy, towncrier, package-data (11 sub-checks) |
 | `check-package-init` | `__version__` defined as string literal, `__all__` defined in package `__init__.py` |
 | `check-version-sync` | Version consistency across pyproject.toml, tbump config, `__init__.py`, and README.md |
@@ -174,7 +174,7 @@ See [`hooks/README.md`](hooks/README.md) for detailed documentation.
 |---------|---------------|
 | `check-makefile-targets` | Required targets (install, test) and recommended targets (docs, build, test-force, update-pre, dev) |
 | `check-workflows` | `.github/workflows/` has test_code.yml with pre-commit and test jobs |
-| `check-precommit-config` | `.pre-commit-config.yaml` includes required hooks (trailing-whitespace, end-of-file-fixer, ruff, ruff-format) |
+| `check-precommit-config` | `.pre-commit-config.yaml` includes required hooks (trailing-whitespace, end-of-file-fixer, ruff or ruff-lint, ruff-format) |
 
 #### Multi-band
 
@@ -215,14 +215,12 @@ Check back for updates as composite actions are added to this repository.
 
 ## Configuration Files
 
-Some configuration files **cannot** be referenced remotely via GitHub Actions and must live directly in each PDK repository:
+Some configuration files **cannot** be referenced remotely and must live directly in each PDK repository:
 
-- `.github/CODEOWNERS` - Code ownership rules
-- `.github/dependabot.yml` - Dependency update configuration
-- `.github/release-drafter.yml` - Release note templates
-- `Makefile` - Build targets (`install`, `test`, `docs`)
-
-These files are provided as templates in `templates/`. Copy them manually into your PDK repository.
+- `.github/dependabot.yml` - Dependency update configuration (template provided)
+- `.github/release-drafter.yml` - Release note templates (template provided)
+- `.github/CODEOWNERS` - Code ownership rules (no template — repo-specific)
+- `Makefile` - Build targets: `install`, `test`, `docs`, `dev` (no template — repo-specific)
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This repository provides reusable automation tooling for Process Design Kit (PDK
 This repository provides four complementary automation patterns:
 
 - **Reusable GitHub Actions Workflows** - Complete CI/CD jobs for testing, docs, releases, and code review
-- **Pre-commit Hooks** - 15 local development checks enforcing PDK organizational standards
+- **Pre-commit Hooks** - 14 PDK compliance checks plus 10 third-party tool wrappers (ruff, codespell, etc.) with centrally controlled versions
 - **Templates** - Reference configuration files for onboarding new PDK repos
 - **Composite Actions** - Shared step sequences for flexible workflow composition (in development)
 
@@ -62,7 +62,7 @@ Pre-commit hooks run locally on developer machines before commits are created. T
 
 The easiest way to onboard is to copy the template files provided in `templates/` into your repo.
 
-**1. Add reusable workflows** (copy from `templates/.github/workflows/`):
+**1. Copy workflow templates** from `templates/.github/workflows/` into your repo. Each is a minimal wrapper:
 ```yaml
 # .github/workflows/test_code.yml
 name: Test code
@@ -73,39 +73,20 @@ on:
 
 jobs:
   test:
-    uses: doplaydo/pdk-ci-workflow/.github/workflows/test_code.yml@v1
-    secrets:
-      GFP_API_KEY: ${{ secrets.GFP_API_KEY }}
+    uses: doplaydo/pdk-ci-workflow/.github/workflows/test_code.yml@main
+    secrets: inherit
 ```
 
-**2. Add pre-commit hooks** (copy from `templates/.pre-commit-config.yaml`):
-```yaml
-# .pre-commit-config.yaml
-repos:
-  - repo: https://github.com/doplaydo/pdk-ci-workflow
-    rev: v1  # Use specific version tag
-    hooks:
-      - id: check-required-files
-      - id: check-pyproject-sections
-      - id: check-package-init
-      - id: check-cells-structure
-      - id: check-tech-structure
-      - id: check-pdk-object
-      - id: check-test-structure
-      - id: check-makefile-targets
-      - id: check-workflows
-      - id: check-multi-band
-      - id: check-no-raw-layers
-      - id: check-no-main-in-cells
-      - id: check-precommit-config
-      - id: check-version-sync
+**2. Set up pre-commit** — add to your `Makefile`:
+```makefile
+dev: install
+	curl -sf https://raw.githubusercontent.com/doplaydo/pdk-ci-workflow/main/templates/.pre-commit-config.yaml -o .pre-commit-config.yaml
+	uv run pre-commit install
 ```
 
-**3. Install pre-commit:**
-```bash
-pip install pre-commit
-pre-commit install
-```
+The canonical pre-commit config is fetched from this repo. It includes all PDK compliance hooks plus third-party tools (ruff, codespell, nbstripout, etc.) with centrally controlled versions. In CI, the `test_code.yml` workflow fetches it automatically.
+
+**3. Add `.pre-commit-config.yaml` to `.gitignore`** — the config is always fetched from upstream, never committed.
 
 ## Reusable Workflows
 
@@ -115,111 +96,33 @@ PDK repos reference these workflows via `workflow_call`. Create thin wrapper wor
 
 | Workflow | Jobs | Description |
 |----------|------|-------------|
-| `test_code.yml` | pre-commit, test_code, test_gfp | Linting (ruff), type checking (pyright), pytest, GFP validation |
+| `test_code.yml` | pre-commit, test_code, test_gfp | Pre-commit (canonical config), pytest, GFP validation |
 | `pages.yml` | build-docs, deploy-docs | Sphinx docs build and GitHub Pages deployment |
-| `claude-pr-review.yml` | claude-review | AI code review via Claude on PRs and `@claude` mentions |
+| `claude-pr-review.yml` | review | AI code review via Claude Sonnet 4 on PRs |
 | `release-drafter.yml` | update_release_draft | Auto-drafted release notes with semantic versioning |
+| `drc.yml` | drc | Design Rule Check with GFP and badge generation |
+| `issue.yml` | add-label | Auto-labels issues with "pdk" tag |
 
-### Usage Examples
-
-#### Testing
-Runs pre-commit checks, pytest, and GFP platform validation in parallel.
+All workflows are called from PDK repos using `secrets: inherit`:
 
 ```yaml
-# .github/workflows/test_code.yml
-name: Test code
-on:
-  pull_request:
-  push:
-    branches: [main]
-
 jobs:
   test:
-    uses: doplaydo/pdk-ci-workflow/.github/workflows/test_code.yml@v1
-    secrets:
-      GFP_API_KEY: ${{ secrets.GFP_API_KEY }}
+    uses: doplaydo/pdk-ci-workflow/.github/workflows/test_code.yml@main
+    secrets: inherit
 ```
 
-**Jobs:**
-- `pre-commit`: Runs ruff (linting/formatting) and pyright (type checking)
-- `test_code`: Runs pytest with Python 3.12 and uv package manager
-- `test_gfp`: Validates against GDSFactory Platform using `uv run gfp test`
+See `templates/.github/workflows/` for ready-to-copy wrappers for each workflow.
 
-**Required secrets:** `GFP_API_KEY`
+### Required Secrets
 
-#### Documentation
-Builds Sphinx documentation and deploys to GitHub Pages.
+PDK repos should have these secrets configured (passed automatically via `secrets: inherit`):
 
-```yaml
-# .github/workflows/pages.yml
-name: Build docs
-on:
-  pull_request:
-  push:
-    branches: [main]
-  workflow_dispatch:
-
-jobs:
-  docs:
-    uses: doplaydo/pdk-ci-workflow/.github/workflows/pages.yml@v1
-```
-
-**Jobs:**
-- `build-docs`: Runs `make docs` and uploads artifact
-- `deploy-docs`: Deploys to GitHub Pages (main branch only)
-
-**Required secrets:** None
-
-#### AI Code Review
-Enables Claude-powered code review on pull requests.
-
-```yaml
-# .github/workflows/claude-pr-review.yml
-name: Claude PR Review
-on:
-  pull_request:
-    types: [opened, synchronize, reopened]
-  issue_comment:
-    types: [created]
-
-jobs:
-  review:
-    uses: doplaydo/pdk-ci-workflow/.github/workflows/claude-pr-review.yml@v1
-    secrets:
-      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-```
-
-**Features:**
-- Automatic review on PR creation and updates
-- Mention `@claude` in comments to request reviews
-- Uses Claude Sonnet 4 (claude-sonnet-4-20250514)
-- Reads Python files, notebooks, and documentation
-- Understands GDSFactory PDK context
-
-**Required secrets:** `ANTHROPIC_API_KEY`
-
-#### Release Drafter
-Automatically generates release notes with semantic versioning.
-
-```yaml
-# .github/workflows/release-drafter.yml
-name: Release Drafter
-on:
-  push:
-    branches: [main]
-
-jobs:
-  draft:
-    uses: doplaydo/pdk-ci-workflow/.github/workflows/release-drafter.yml@v1
-```
-
-**Features:**
-- Semantic versioning based on PR labels (major/minor/patch)
-- Auto-categorizes changes: Breaking, New, Bug Fixes, Maintenance, Docs, Dependencies
-- Auto-labels PRs based on branch patterns (feat/*, fix/*, etc.)
-- Excludes PRs labeled `skip-changelog`
-
-**Required secrets:** None (uses `GITHUB_TOKEN`)
+| Secret | Used by |
+|--------|---------|
+| `GFP_API_KEY` | test_code, pages, drc |
+| `ANTHROPIC_API_KEY` | claude-pr-review |
+| `GITHUB_TOKEN` | release-drafter, issue (automatic) |
 
 ## Pre-commit Hooks
 
@@ -227,25 +130,12 @@ Pre-commit hooks run locally before commits to enforce PDK structural standards.
 
 See [`hooks/README.md`](hooks/README.md) for detailed documentation of each hook.
 
-### Installation
+### Setup
 
-Add to your `.pre-commit-config.yaml` (or use the template from `templates/.pre-commit-config.yaml`):
+The canonical pre-commit config is managed centrally in `templates/.pre-commit-config.yaml`. It includes all PDK compliance hooks plus third-party tools (ruff, codespell, nbstripout, pretty-format-toml, etc.) with versions controlled via `additional_dependencies`.
 
-```yaml
-repos:
-  - repo: https://github.com/doplaydo/pdk-ci-workflow
-    rev: v1  # Use specific version tag
-    hooks:
-      - id: check-required-files
-      - id: check-pyproject-sections
-      # ... add hooks as needed
-```
-
-Then install:
-```bash
-pip install pre-commit
-pre-commit install
-```
+- **CI:** The `test_code.yml` workflow fetches the canonical config automatically.
+- **Local:** PDK repos download it via `make dev` (see Quick Start above).
 
 ### Available Hooks
 
@@ -284,17 +174,19 @@ pre-commit install
 
 ## Templates
 
-Reference configuration files are provided in `templates/` for onboarding new PDK repos. Copy these files into your repo and replace `{{VERSION}}` placeholders with the desired pdk-ci-workflow version tag (e.g., `v1`).
+Reference configuration files are provided in `templates/` for onboarding new PDK repos. Copy these files into your repo as-is — they use `@main` and `secrets: inherit`, no modification needed.
 
 ### Template Files
 
 | Template | Purpose |
 |----------|---------|
-| `.pre-commit-config.yaml` | Pre-commit hook config with all 14 PDK compliance hooks |
-| `.github/workflows/test_code.yml` | Thin wrapper calling reusable test workflow |
-| `.github/workflows/pages.yml` | Thin wrapper calling reusable docs workflow |
-| `.github/workflows/claude-pr-review.yml` | Thin wrapper for AI code review |
-| `.github/workflows/release-drafter.yml` | Thin wrapper for release management |
+| `.pre-commit-config.yaml` | Canonical pre-commit config (PDK hooks + third-party tools with centralized versions) |
+| `.github/workflows/test_code.yml` | Pre-commit, pytest, and GFP validation |
+| `.github/workflows/pages.yml` | Sphinx docs build and GitHub Pages deployment |
+| `.github/workflows/claude-pr-review.yml` | AI code review via Claude |
+| `.github/workflows/release-drafter.yml` | Semantic versioning and release notes |
+| `.github/workflows/drc.yml` | Design Rule Check via GFP |
+| `.github/workflows/issue.yml` | Auto-label PDK issues |
 | `.github/dependabot.yml` | Monthly pip and github-actions dependency updates |
 | `.github/release-drafter.yml` | Release note template with semantic versioning categories |
 
@@ -333,9 +225,9 @@ PDK repositories consuming these workflows need:
 
 ### GitHub Secrets
 
-For PDK repositories:
-- `GFP_API_KEY` - For GDSFactory Platform validation (`test_code.yml`)
-- `ANTHROPIC_API_KEY` - For Claude code reviews (`claude-pr-review.yml`)
+For PDK repositories (passed automatically via `secrets: inherit`):
+- `GFP_API_KEY` - For GDSFactory Platform validation (test_code, pages, drc)
+- `ANTHROPIC_API_KEY` - For Claude code reviews (claude-pr-review)
 
 ### GitHub Pages (for documentation)
 Enable GitHub Pages in your repository settings:
@@ -364,7 +256,7 @@ Enable GitHub Pages in your repository settings:
 ### Adding a New Template
 
 1. Create the template file in `templates/` mirroring the target path
-2. Use `{{VERSION}}` placeholder where the pdk-ci-workflow version tag should appear
+2. Use `@main` to reference pdk-ci-workflow and `secrets: inherit` to pass secrets
 
 ### Versioning
 
@@ -373,7 +265,7 @@ This repository uses semantic versioning:
 - **Minor (v1.1.0):** New workflows, hooks, or backward-compatible features
 - **Patch (v1.0.1):** Bug fixes, documentation updates
 
-Consuming repositories should pin to major version tags (e.g., `@v1`) to receive minor updates and patches automatically while avoiding breaking changes.
+PDK repositories currently reference `@main` for all workflows and pre-commit hooks.
 
 ## Repository Structure
 
@@ -385,7 +277,7 @@ pdk-ci-workflow/
 │   └── README.md
 ├── hooks/                  # Pre-commit hook implementations
 │   ├── _utils.py           # Shared utilities (TOML/YAML, AST, CheckResult)
-│   ├── check_*.py          # Individual hook scripts (15 total)
+│   ├── check_*.py          # Individual hook scripts (14 total)
 │   └── README.md
 ├── templates/              # Config templates synced to PDK repos
 │   ├── .pre-commit-config.yaml
@@ -395,7 +287,7 @@ pdk-ci-workflow/
 │   └── README.md
 ├── actions/                # Composite actions (in development)
 │   └── README.md
-├── .pre-commit-hooks.yml   # Hook registration for pre-commit framework
+├── .pre-commit-hooks.yaml  # Hook registration for pre-commit framework
 └── pyproject.toml          # Package config and hook entry points
 ```
 

--- a/README.md
+++ b/README.md
@@ -58,11 +58,10 @@ Pre-commit hooks run locally on developer machines before commits are created. T
 
 ## Quick Start
 
-### For consuming PDK repositories:
+### 1. Copy workflow templates
 
-The easiest way to onboard is to copy the template files provided in `templates/` into your repo.
+Copy all files from `templates/.github/workflows/` into your repo. Each is a one-liner that delegates to this repo:
 
-**1. Copy workflow templates** from `templates/.github/workflows/` into your repo. Each is a minimal wrapper:
 ```yaml
 # .github/workflows/test_code.yml
 name: Test code
@@ -77,16 +76,29 @@ jobs:
     secrets: inherit
 ```
 
-**2. Set up pre-commit** — add to your `Makefile`:
+### 2. Set up pre-commit
+
+Add to your `Makefile`:
 ```makefile
 dev: install
 	curl -sf https://raw.githubusercontent.com/doplaydo/pdk-ci-workflow/main/templates/.pre-commit-config.yaml -o .pre-commit-config.yaml
 	uv run pre-commit install
 ```
 
-The canonical pre-commit config is fetched from this repo. It includes all PDK compliance hooks plus third-party tools (ruff, codespell, nbstripout, etc.) with centrally controlled versions. In CI, the `test_code.yml` workflow fetches it automatically.
+Add to your `.gitignore`:
+```
+.pre-commit-config.yaml
+```
 
-**3. Add `.pre-commit-config.yaml` to `.gitignore`** — the config is always fetched from upstream, never committed.
+Then run `make dev`.
+
+### How pre-commit works
+
+- **The config is never committed to PDK repos.** It lives in this repo at `templates/.pre-commit-config.yaml` and is always fetched from upstream.
+- **In CI:** The `test_code.yml` reusable workflow fetches the canonical config automatically before running `pre-commit run --all-files`. No setup needed in the PDK repo.
+- **Locally:** `make dev` downloads the config and installs the git hooks. Pre-commit then runs automatically on every `git commit`.
+- **Versions of all tools** (ruff, codespell, nbstripout, pretty-format-toml, etc.) are controlled centrally in this repo via `additional_dependencies`. Bumping a version here propagates to all PDK repos — no downstream PRs needed.
+- **PDK-specific overrides** (e.g. custom `check-yaml` excludes): keep a committed `.pre-commit-config.yaml` instead, still referencing pdk-ci-workflow as the only repo.
 
 ## Reusable Workflows
 
@@ -126,16 +138,14 @@ PDK repos should have these secrets configured (passed automatically via `secret
 
 ## Pre-commit Hooks
 
-Pre-commit hooks run locally before commits to enforce PDK structural standards. All hooks are repo-level checks (`always_run: true`, `pass_filenames: false`) that use errors for required items and warnings for recommended items.
+Two types of hooks are defined in `.pre-commit-hooks.yaml`:
 
-See [`hooks/README.md`](hooks/README.md) for detailed documentation of each hook.
+- **14 PDK compliance hooks** (`hooks/*.py`) — validate repo structure, cells, tech, tests, etc.
+- **10 third-party wrapper hooks** — ruff, codespell, nbstripout, trailing-whitespace, etc. with versions pinned via `additional_dependencies` so they're controlled centrally
 
-### Setup
+All hooks use `always_run: true` and `pass_filenames: false` (repo-level checks). Errors = failure, warnings = pass but alert.
 
-The canonical pre-commit config is managed centrally in `templates/.pre-commit-config.yaml`. It includes all PDK compliance hooks plus third-party tools (ruff, codespell, nbstripout, pretty-format-toml, etc.) with versions controlled via `additional_dependencies`.
-
-- **CI:** The `test_code.yml` workflow fetches the canonical config automatically.
-- **Local:** PDK repos download it via `make dev` (see Quick Start above).
+See [`hooks/README.md`](hooks/README.md) for detailed documentation.
 
 ### Available Hooks
 
@@ -248,7 +258,7 @@ Enable GitHub Pages in your repository settings:
 
 1. Create Python script in `hooks/` directory
 2. Add entry point to `pyproject.toml` under `[project.scripts]`
-3. Register hook in `.pre-commit-hooks.yml` with unique ID
+3. Register hook in `.pre-commit-hooks.yaml` with unique ID
 4. Add the hook to `templates/.pre-commit-config.yaml`
 5. Document in `hooks/README.md`
 6. Test locally: `pre-commit try-repo . <hook-id> --verbose --all-files`

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -1,6 +1,6 @@
 # hooks/
 
-Pre-commit hook scripts for PDK template compliance. These are referenced by `.pre-commit-hooks.yml` at the repository root and executed by the [pre-commit](https://pre-commit.com/) framework when consuming repos point to this repository in their `.pre-commit-config.yaml`.
+Pre-commit hook scripts for PDK template compliance. These are referenced by `.pre-commit-hooks.yaml` at the repository root and executed by the [pre-commit](https://pre-commit.com/) framework when consuming repos point to this repository in their `.pre-commit-config.yaml`.
 
 Each hook is a self-contained Python script that validates some aspect of a PDK repository's structure and configuration. Hooks use **errors** for required items (fail the hook) and **warnings** for recommended items (print but pass).
 
@@ -32,7 +32,7 @@ Each hook is a self-contained Python script that validates some aspect of a PDK 
 | `check-test-structure` | `check_test_structure.py` | `tests/` directory exists with test files, GDS reference directories, `difftest()` calls, and `data_regression` usage |
 | `check-makefile-targets` | `check_makefile_targets.py` | Required targets: install, test. Recommended: docs, build, test-force, update-pre, dev. Content checks: uv sync in install, pytest in test |
 | `check-workflows` | `check_workflows.py` | `.github/workflows/` has test_code.yml (or test.yml) with pre-commit job and test job; recommends release.yml |
-| `check-precommit-config` | `check_precommit_config.py` | `.pre-commit-config.yaml` includes required hooks (end-of-file-fixer, trailing-whitespace, ruff, ruff-format) and recommended hooks (nbstripout, codespell) |
+| `check-precommit-config` | `check_precommit_config.py` | `.pre-commit-config.yaml` includes required hooks (end-of-file-fixer, trailing-whitespace, ruff or ruff-lint, ruff-format) and recommended hooks (nbstripout, codespell) |
 
 ### Multi-band
 
@@ -74,7 +74,7 @@ if __name__ == "__main__":
 ```
 
 - Entry points are registered in `pyproject.toml` under `[project.scripts]`
-- Hook metadata is registered in `.pre-commit-hooks.yml`
+- Hook metadata is registered in `.pre-commit-hooks.yaml` at repo root
 - All hooks use `always_run: true` and `pass_filenames: false` (repo-level structural checks)
 
 ## Adding a New Hook
@@ -84,7 +84,7 @@ if __name__ == "__main__":
    ```toml
    check_<name> = "hooks.check_<name>:main"
    ```
-3. Register in `.pre-commit-hooks.yml`:
+3. Register in `.pre-commit-hooks.yaml`:
    ```yaml
    - id: check-<name>
      name: <Human-readable name>

--- a/templates/.github/workflows/claude-pr-review.yml
+++ b/templates/.github/workflows/claude-pr-review.yml
@@ -7,6 +7,5 @@ on:
 
 jobs:
   review:
-    uses: doplaydo/pdk-ci-workflow/.github/workflows/claude-pr-review.yml@{{VERSION}}
-    secrets:
-      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+    uses: doplaydo/pdk-ci-workflow/.github/workflows/claude-pr-review.yml@main
+    secrets: inherit

--- a/templates/.github/workflows/drc.yml
+++ b/templates/.github/workflows/drc.yml
@@ -1,0 +1,10 @@
+name: DRC Check
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+
+jobs:
+  drc:
+    uses: doplaydo/pdk-ci-workflow/.github/workflows/drc.yml@main
+    secrets: inherit

--- a/templates/.github/workflows/issue.yml
+++ b/templates/.github/workflows/issue.yml
@@ -1,0 +1,23 @@
+name: Auto-label PDK issues
+on:
+  issues:
+    types:
+      - opened
+      - edited
+      - deleted
+      - pinned
+      - unpinned
+      - closed
+      - reopened
+      - assigned
+      - unassigned
+      - unlabeled
+      - locked
+      - unlocked
+      - transferred
+      - milestoned
+      - demilestoned
+
+jobs:
+  label:
+    uses: doplaydo/pdk-ci-workflow/.github/workflows/issue.yml@main

--- a/templates/.github/workflows/pages.yml
+++ b/templates/.github/workflows/pages.yml
@@ -7,5 +7,5 @@ on:
 
 jobs:
   docs:
-    if: github.event_name != 'pull_request' || github.event.pull_request.user.login != 'dependabot[bot]'
-    uses: doplaydo/pdk-ci-workflow/.github/workflows/pages.yml@{{VERSION}}
+    uses: doplaydo/pdk-ci-workflow/.github/workflows/pages.yml@main
+    secrets: inherit

--- a/templates/.github/workflows/release-drafter.yml
+++ b/templates/.github/workflows/release-drafter.yml
@@ -2,7 +2,8 @@ name: Release Drafter
 on:
   push:
     branches: [main]
+  workflow_dispatch:
 
 jobs:
   draft:
-    uses: doplaydo/pdk-ci-workflow/.github/workflows/release-drafter.yml@{{VERSION}}
+    uses: doplaydo/pdk-ci-workflow/.github/workflows/release-drafter.yml@main

--- a/templates/.github/workflows/test_code.yml
+++ b/templates/.github/workflows/test_code.yml
@@ -1,9 +1,4 @@
 name: Test code
-
-# CI pre-commit uses the canonical config from pdk-ci-workflow (fetched
-# automatically by the reusable workflow). No local .pre-commit-config.yaml
-# needed in CI.
-
 on:
   pull_request:
   push:
@@ -11,6 +6,5 @@ on:
 
 jobs:
   test:
-    uses: doplaydo/pdk-ci-workflow/.github/workflows/test_code.yml@{{VERSION}}
-    secrets:
-      GFP_API_KEY: ${{ secrets.GFP_API_KEY }}
+    uses: doplaydo/pdk-ci-workflow/.github/workflows/test_code.yml@main
+    secrets: inherit

--- a/templates/README.md
+++ b/templates/README.md
@@ -1,42 +1,34 @@
 # templates/
 
-Reference configuration files for onboarding new PDK repositories. Copy these files into your PDK repo and replace `{{VERSION}}` placeholders with the desired pdk-ci-workflow version tag.
+Reference configuration files for onboarding new PDK repositories. Copy these files into your PDK repo as-is — they reference `@main` so they always use the latest version of pdk-ci-workflow.
 
-## Template Files
+## Workflow Templates
+
+All workflow templates are minimal wrappers that delegate to the reusable workflows defined in this repo. They use `secrets: inherit` to pass all available secrets automatically.
 
 | File | Purpose |
 |------|---------|
-| `.pre-commit-config.yaml` | Pre-commit hook config with all 15 PDK compliance hooks, plus standard hooks (ruff, pre-commit-hooks, pyright) |
-| `.github/workflows/test_code.yml` | Thin wrapper calling the reusable test workflow (pre-commit, pytest, GFP validation) |
-| `.github/workflows/pages.yml` | Thin wrapper calling the reusable docs build and GitHub Pages deployment workflow |
-| `.github/workflows/claude-pr-review.yml` | Thin wrapper for AI code review, passes `ANTHROPIC_API_KEY` secret |
-| `.github/workflows/release-drafter.yml` | Thin wrapper calling the reusable release drafter workflow |
-| `.github/dependabot.yml` | Dependabot config for monthly pip and github-actions dependency updates |
-| `.github/release-drafter.yml` | Release note template with semantic versioning categories and auto-labeler rules |
+| `.github/workflows/test_code.yml` | Pre-commit, pytest, and GFP validation |
+| `.github/workflows/pages.yml` | Sphinx docs build and GitHub Pages deployment |
+| `.github/workflows/claude-pr-review.yml` | AI code review via Claude |
+| `.github/workflows/release-drafter.yml` | Semantic versioning and release notes |
+| `.github/workflows/drc.yml` | Design Rule Check via GFP |
+| `.github/workflows/issue.yml` | Auto-label PDK issues |
 
-## Version Placeholder
+## Other Templates
 
-All template files use `{{VERSION}}` as a placeholder where the pdk-ci-workflow version tag should appear. Replace this with the actual tag when copying:
+| File | Purpose |
+|------|---------|
+| `.pre-commit-config.yaml` | Canonical pre-commit config — all PDK hooks + third-party tools (ruff, codespell, etc.) with centrally controlled versions |
+| `.github/dependabot.yml` | Monthly pip and github-actions dependency updates |
+| `.github/release-drafter.yml` | Release note template with semantic versioning categories |
 
-```yaml
-# In template:
-uses: doplaydo/pdk-ci-workflow/.github/workflows/test_code.yml@{{VERSION}}
+## Pre-commit Config
 
-# After replacement (e.g., tag v0.2.0):
-uses: doplaydo/pdk-ci-workflow/.github/workflows/test_code.yml@v0.2.0
+The `.pre-commit-config.yaml` template is the canonical config for all PDK repos. In CI, it is fetched automatically by the `test_code.yml` reusable workflow. For local development, PDK repos download it via `make dev`:
+
+```makefile
+dev: install
+	curl -sf https://raw.githubusercontent.com/doplaydo/pdk-ci-workflow/main/templates/.pre-commit-config.yaml -o .pre-commit-config.yaml
+	uv run pre-commit install
 ```
-
-The `.pre-commit-config.yaml` template also uses the placeholder for the `rev:` field:
-```yaml
-- repo: https://github.com/doplaydo/pdk-ci-workflow
-  rev: "{{VERSION}}"
-```
-
-## Adding a New Template
-
-1. Create the file under `templates/` mirroring its target path in the PDK repo. For example, `templates/.github/workflows/new-workflow.yml` will be copied to `.github/workflows/new-workflow.yml` in the PDK.
-2. Use `{{VERSION}}` wherever the pdk-ci-workflow version tag should appear.
-3. Test the replacement locally:
-   ```bash
-   sed 's/{{VERSION}}/v0.2.0/g' templates/.github/workflows/new-workflow.yml
-   ```

--- a/templates/README.md
+++ b/templates/README.md
@@ -1,34 +1,37 @@
 # templates/
 
-Reference configuration files for onboarding new PDK repositories. Copy these files into your PDK repo as-is — they reference `@main` so they always use the latest version of pdk-ci-workflow.
+Copy these files into your PDK repo as-is. No modification needed.
 
-## Workflow Templates
+## Workflows
 
-All workflow templates are minimal wrappers that delegate to the reusable workflows defined in this repo. They use `secrets: inherit` to pass all available secrets automatically.
+Minimal wrappers — each just calls the upstream reusable workflow with `secrets: inherit`.
 
 | File | Purpose |
 |------|---------|
-| `.github/workflows/test_code.yml` | Pre-commit, pytest, and GFP validation |
-| `.github/workflows/pages.yml` | Sphinx docs build and GitHub Pages deployment |
+| `.github/workflows/test_code.yml` | Pre-commit, pytest, GFP validation |
+| `.github/workflows/pages.yml` | Sphinx docs build + GitHub Pages |
 | `.github/workflows/claude-pr-review.yml` | AI code review via Claude |
-| `.github/workflows/release-drafter.yml` | Semantic versioning and release notes |
+| `.github/workflows/release-drafter.yml` | Semantic versioning + release notes |
 | `.github/workflows/drc.yml` | Design Rule Check via GFP |
 | `.github/workflows/issue.yml` | Auto-label PDK issues |
 
-## Other Templates
-
-| File | Purpose |
-|------|---------|
-| `.pre-commit-config.yaml` | Canonical pre-commit config — all PDK hooks + third-party tools (ruff, codespell, etc.) with centrally controlled versions |
-| `.github/dependabot.yml` | Monthly pip and github-actions dependency updates |
-| `.github/release-drafter.yml` | Release note template with semantic versioning categories |
-
 ## Pre-commit Config
 
-The `.pre-commit-config.yaml` template is the canonical config for all PDK repos. In CI, it is fetched automatically by the `test_code.yml` reusable workflow. For local development, PDK repos download it via `make dev`:
+`.pre-commit-config.yaml` is the **canonical config** for all PDK repos.
+
+- **Do not commit this file** — add it to `.gitignore`
+- **CI fetches it automatically** via the `test_code.yml` workflow
+- **Locally**, `make dev` downloads it:
 
 ```makefile
 dev: install
 	curl -sf https://raw.githubusercontent.com/doplaydo/pdk-ci-workflow/main/templates/.pre-commit-config.yaml -o .pre-commit-config.yaml
 	uv run pre-commit install
 ```
+
+## Other Config
+
+| File | Purpose |
+|------|---------|
+| `.github/dependabot.yml` | Monthly pip + github-actions updates |
+| `.github/release-drafter.yml` | Release note categories + auto-labeler |


### PR DESCRIPTION
## Summary

Ensures every reusable workflow has a template, and every template is the bare minimum a PDK repo needs.

### Changes

| Template | What changed |
|----------|-------------|
| `test_code.yml` | `secrets: inherit` instead of explicit `GFP_API_KEY`, remove comment block, `@main` |
| `pages.yml` | Add `secrets: inherit` (was missing — caused GFP_API_KEY/SIMCLOUD_APIKEY not being passed), remove redundant dependabot `if`, `@main` |
| `claude-pr-review.yml` | `secrets: inherit` instead of explicit `ANTHROPIC_API_KEY`, `@main` |
| `release-drafter.yml` | Add `workflow_dispatch`, `@main` |
| `drc.yml` | **New** — was missing entirely |
| `issue.yml` | **New** — was missing entirely |

### Why `secrets: inherit`

Explicit secret passing (`secrets: GFP_API_KEY: ${{ secrets.GFP_API_KEY }}`) requires PDK repos to know which secrets each workflow needs and breaks silently when a new secret is added upstream. `secrets: inherit` passes all available secrets automatically.

### Why `@main`

All downstream PDK repos already use `@main`. The `{{VERSION}}` placeholder was never substituted in practice.

## Test plan
- [ ] Verify templates match what working PDK repos (ant, ph18) use
- [ ] Verify pages workflow receives secrets after migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)