### PR TITLE
Ensure pdk label exists before applying it

### DIFF
--- a/.github/workflows/issue.yml
+++ b/.github/workflows/issue.yml
@@ -25,7 +25,9 @@ jobs:
       issues: write
     steps:
       - name: Add label
-        run: gh issue edit ${{ github.event.issue.number }} --add-label "pdk"
+        run: |
+          gh label create "pdk" --force
+          gh issue edit ${{ github.event.issue.number }} --add-label "pdk"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}


### PR DESCRIPTION
## Summary
- `gh issue edit --add-label "pdk"` fails if the label doesn't exist in the consuming repo yet
- Added `gh label create "pdk" --force` before the edit — creates the label on first use, no-op afterwards

## Test plan
- [x] Verified fix on `doplaydo/pdks` (label created manually for immediate fix)
- [ ] Trigger the workflow on a repo that doesn't have the `pdk` label to confirm it gets created automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)