### PR TITLE
feat: upload difftest artifacts on test failure

### DIFF
--- a/.github/workflows/test_code.yml
+++ b/.github/workflows/test_code.yml
@@ -44,9 +44,7 @@ jobs:
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: difftest-report-test_code
-          path: |
-            tests/
-            build/
+          path: test_diffs/
           if-no-files-found: ignore
   test_gfp:
     runs-on: ubuntu-latest
@@ -68,8 +66,6 @@ jobs:
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: difftest-report-test_gfp
-          path: |
-            tests/
-            build/
+          path: test_diffs/
           if-no-files-found: ignore
         

--- a/.github/workflows/test_code.yml
+++ b/.github/workflows/test_code.yml
@@ -68,4 +68,5 @@ jobs:
           name: difftest-report-test_gfp
           path: test_diffs/
           if-no-files-found: ignore
+          retention-days: 14
         

--- a/.github/workflows/test_code.yml
+++ b/.github/workflows/test_code.yml
@@ -39,6 +39,15 @@ jobs:
           make install
       - name: Test with pytest
         run: make test
+      - name: Upload difftest artifacts
+        if: failure()
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: difftest-report-test_code
+          path: |
+            tests/
+            build/
+          if-no-files-found: ignore
   test_gfp:
     runs-on: ubuntu-latest
     steps:
@@ -54,4 +63,13 @@ jobs:
           make install
       - name: Test with pytest
         run: uv run gfp test
+      - name: Upload difftest artifacts
+        if: failure()
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: difftest-report-test_gfp
+          path: |
+            tests/
+            build/
+          if-no-files-found: ignore
         

--- a/.github/workflows/test_code.yml
+++ b/.github/workflows/test_code.yml
@@ -70,4 +70,4 @@ jobs:
           path: test_diffs/
           if-no-files-found: ignore
           retention-days: 14
-        
+          if-no-files-found: ignore

--- a/.github/workflows/test_code.yml
+++ b/.github/workflows/test_code.yml
@@ -46,6 +46,7 @@ jobs:
           name: difftest-report-test_code
           path: test_diffs/
           if-no-files-found: ignore
+          retention-days: 14
   test_gfp:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary
- Adds artifact upload steps to both `test_code` and `test_gfp` jobs in `test_code.yml`
- Uploads `tests/` and `build/` directories when tests fail (`if: failure()`)
- Uses `if-no-files-found: ignore` so the step doesn't error when directories don't exist

## Test plan
- [ ] Trigger a failing difftest in a PDK repo and verify the artifact appears in the workflow run
- [ ] Verify passing tests do not upload artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)