### PR TITLE
fix: push DRC badge directly to main

### DIFF
--- a/.github/workflows/drc.yml
+++ b/.github/workflows/drc.yml
@@ -67,11 +67,6 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add badges/drc.svg
           if ! git diff --staged --quiet; then
-            branch="update-drc-badge"
-            git checkout -b "$branch"
-            git commit -m "update DRC badge"
-            git push -f origin "$branch"
-            gh pr create --title "update DRC badge" --body "Automated DRC badge update." --base main --head "$branch" || true
+            git commit -m "update DRC badge [skip ci]"
+            git push origin HEAD:main
           fi
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- DRC badge updates now push directly to main instead of creating a PR requiring approval
- Added `[skip ci]` to the commit message to prevent infinite workflow loops
- Removed unused `GH_TOKEN` env since `gh pr create` is no longer needed

## Test plan
- [ ] Run DRC workflow on a PDK repo and verify badge commits directly to main
- [ ] Verify `[skip ci]` prevents re-triggering

🤖 Generated with [Claude Code](https://claude.com/claude-code)