### PR TITLE
fix: remove duplicate YAML key in test_code workflow

### DIFF
--- a/.github/workflows/test_code.yml
+++ b/.github/workflows/test_code.yml
@@ -70,4 +70,3 @@ jobs:
           path: test_diffs/
           if-no-files-found: ignore
           retention-days: 14
-          if-no-files-found: ignore


### PR DESCRIPTION
## Summary
- Remove duplicate \`if-no-files-found: ignore\` key in test_code.yml (test_gfp job)
- The duplicate key caused GitHub Actions to silently fail to parse the workflow file, so callers using \`uses: doplaydo/pdk-ci-workflow/.github/workflows/test_code.yml@main\` got 0 jobs running and a generic failure conclusion.

## Test plan
- [ ] Verify a downstream PDK CI run successfully parses and runs jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)