### PR TITLE
templates(dependabot): switch to uv ecosystem

### DIFF
--- a/templates/.github/dependabot.yml
+++ b/templates/.github/dependabot.yml
@@ -1,6 +1,8 @@
 version: 2
 updates:
   - package-ecosystem: "uv"
+    cooldown:
+      default-days: 7
     directory: "/"
     schedule:
       interval: monthly

--- a/templates/.github/dependabot.yml
+++ b/templates/.github/dependabot.yml
@@ -6,6 +6,8 @@ updates:
     directory: "/"
     schedule:
       interval: monthly
+    ignore:
+      - dependency-name: "doplaydo/*"
 
   - package-ecosystem: github-actions
     cooldown:

--- a/templates/.github/dependabot.yml
+++ b/templates/.github/dependabot.yml
@@ -1,11 +1,15 @@
 version: 2
 updates:
-  - package-ecosystem: "pip"
+  - package-ecosystem: "uv"
     directory: "/"
     schedule:
       interval: monthly
 
   - package-ecosystem: github-actions
+    cooldown:
+      default-days: 7
     directory: /
     schedule:
       interval: monthly
+    ignore:
+      - dependency-name: "doplaydo/*"


### PR DESCRIPTION
Updates the centralized Dependabot template that PDK repos copy:

- `package-ecosystem: uv` (was `pip`) — picks up changes via `uv.lock`
- 7-day cooldown on github-actions updates
- Ignores `doplaydo/*` action updates (managed centrally)

Companion PRs in every PDK repo apply this template (search for branch `dependabot-uv`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)