### PR TITLE
revert DRC badge push: use PR flow instead of direct push to main

### DIFF
--- a/.github/workflows/drc.yml
+++ b/.github/workflows/drc.yml
@@ -69,7 +69,7 @@ jobs:
           if ! git diff --staged --quiet; then
             branch="update-drc-badge"
             git checkout -b "$branch"
-            git commit -m "update DRC badge"
+            git commit -m "update DRC badge [skip ci]"
             git push -f origin "$branch"
             gh pr create --title "update DRC badge" --body "Automated DRC badge update." --base main --head "$branch" || true
           fi

--- a/.github/workflows/drc.yml
+++ b/.github/workflows/drc.yml
@@ -67,6 +67,11 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add badges/drc.svg
           if ! git diff --staged --quiet; then
-            git commit -m "update DRC badge [skip ci]"
-            git push origin HEAD:main
+            branch="update-drc-badge"
+            git checkout -b "$branch"
+            git commit -m "update DRC badge"
+            git push -f origin "$branch"
+            gh pr create --title "update DRC badge" --body "Automated DRC badge update." --base main --head "$branch" || true
           fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
Revert #58 — direct push to main fails on repos with branch protection (29/35 PDK repos). Go back to the PR-creation flow until #64 (GitHub App bypass actor) is implemented.

Closes #62