### PR TITLE
fix: terse caveman-style review prompt

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -29,21 +29,17 @@ jobs:
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}
 
-            Please review this pull request with a focus on:
-            - Code quality and best practices
-            - Potential bugs or issues
-            - Security implications
-            - Performance considerations
+            Review this PR. Focus: bugs, security, correctness. Skip style unless broken.
 
-            Note: The PR branch is already checked out in the current working directory.
-
-            Note the following guidelines for your review:
-            - Do not write positive feedback or general comments. Only provide constructive criticism and actionable feedback. If there are no issues, no need to comment.
-            - Get familiar with the codebase by reading ./AGENTS.md in the repo root.
-            - You are called on new commits to the PR, so focus on the latest changes and how they integrate with the existing code. Avoid redundant comments on unchanged code.
+            Rules:
+            - Read ./AGENTS.md first.
+            - Only new changes matter. No comments on unchanged code.
+            - No positive feedback. No summaries. No pleasantries.
+            - If no issues: post nothing.
+            - Each issue = one line: `[file:line] problem. fix.`
 
             Use `gh pr comment` for top-level feedback.
-            Use `mcp__github_inline_comment__create_inline_comment` to highlight specific code issues.
+            Use `mcp__github_inline_comment__create_inline_comment` for inline issues.
             Only post GitHub comments - don't submit review text as messages.
           claude_args: |
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -29,17 +29,26 @@ jobs:
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}
 
-            Review this PR. Focus: bugs, security, correctness. Skip style unless broken.
+            Please review this pull request with a focus on:
+            - Code quality and best practices
+            - Potential bugs or issues
+            - Security implications
+            - Performance considerations
 
-            Rules:
-            - Read ./AGENTS.md first.
-            - Only new changes matter. No comments on unchanged code.
-            - No positive feedback. No summaries. No pleasantries.
-            - If no issues: post nothing.
-            - Each issue = one line: `[file:line] problem. fix.`
+            Note: The PR branch is already checked out in the current working directory.
+
+            Note the following guidelines for your review:
+            - Do not write positive feedback or general comments. Only provide constructive criticism and actionable feedback. If there are no issues, no need to comment.
+            - Get familiar with the codebase by reading ./AGENTS.md in the repo root.
+            - You are called on new commits to the PR, so focus on the latest changes and how they integrate with the existing code. Avoid redundant comments on unchanged code.
+
+            Output format — ultra-terse, one line per issue:
+            - Drop articles (a/an/the), filler words, pleasantries, and preamble.
+            - Each issue: `[file:line] problem. fix.`
+            - No summaries. No "Overall, ...". No positive remarks.
 
             Use `gh pr comment` for top-level feedback.
-            Use `mcp__github_inline_comment__create_inline_comment` for inline issues.
+            Use `mcp__github_inline_comment__create_inline_comment` to highlight specific code issues.
             Only post GitHub comments - don't submit review text as messages.
           claude_args: |
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"


### PR DESCRIPTION
Closes #66

Replace verbose review prompt with one-liner-per-issue format: `[file:line] problem. fix.`