### PR TITLE
fix: support PDK repos without build_cell.py

### DIFF
--- a/.github/workflows/drc.yml
+++ b/.github/workflows/drc.yml
@@ -27,6 +27,18 @@ jobs:
         run: uv sync --all-extras
       - name: Build cell
         run: uv run python build_cell.py all_cells
+        if: hashFiles('build_cell.py') != ''
+      - name: Build cell (inline)
+        if: hashFiles('build_cell.py') == ''
+        run: |
+          uv run python - << 'EOF'
+          from pathlib import Path
+          from gdsfactoryplus.core.pdk import get_pdk, register_cells
+          Path("build/gds").mkdir(parents=True, exist_ok=True)
+          register_cells()
+          c = get_pdk().cells["all_cells"]()
+          c.write_gds("build/gds/all_cells.gds")
+          EOF
       - name: Run DRC
         run: |
           mkdir -p build/lyrdb


### PR DESCRIPTION
Closes #59

`build_cell.py` is identical across all 15 PDK repos that have it — no customization. PDKs without the file fail at the DRC step.

**Fix:** two conditional steps using `hashFiles()`:
- if `build_cell.py` present → use it (no behavior change for existing repos)
- if absent → run equivalent inline Python via `uv run python -`