### PR TITLE
ci: add reusable workflows for metrics and badges

### DIFF
--- a/.github/workflows/model_coverage.yml
+++ b/.github/workflows/model_coverage.yml
@@ -1,0 +1,52 @@
+name: Model Coverage
+on:
+  workflow_call:
+    secrets:
+      GFP_API_KEY:
+        required: false
+env:
+  GFP_API_KEY: ${{ secrets.GFP_API_KEY }}
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  model-coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+        with:
+          python-version: "3.12"
+      - name: Install dependencies
+        run: make install
+      - name: Check model coverage
+        run: |
+          uv run python - <<'PYEOF'
+          import importlib, os, tomllib
+          from pathlib import Path
+
+          with open("pyproject.toml", "rb") as f:
+              cfg = tomllib.load(f)
+          pdk_module = cfg.get("tool", {}).get("gdsfactoryplus", {}).get("pdk", {}).get("name", "")
+          if not pdk_module:
+              print("No [tool.gdsfactoryplus.pdk] name found in pyproject.toml")
+              raise SystemExit(1)
+
+          mod = importlib.import_module(pdk_module)
+          pdk = mod.PDK
+          pdk.activate()
+          cells = pdk.cells
+          models = getattr(pdk, "models", {}) or {}
+          total = len(cells)
+          with_model = len(set(cells) & set(models))
+          pct = (with_model / total * 100) if total else 0
+
+          summary = os.environ.get("GITHUB_STEP_SUMMARY", "/dev/null")
+          with open(summary, "a") as f:
+              f.write(f"## Model Coverage\n\n")
+              f.write(f"| Metric | Value |\n|--------|-------|\n")
+              f.write(f"| Cells | {total} |\n")
+              f.write(f"| Cells with model | {with_model} |\n")
+              f.write(f"| Coverage | {pct:.1f}% |\n")
+          print(f"Model coverage: {with_model}/{total} ({pct:.1f}%)")
+          PYEOF

--- a/.github/workflows/model_regression.yml
+++ b/.github/workflows/model_regression.yml
@@ -1,0 +1,42 @@
+name: Model Regression
+on:
+  workflow_call:
+    secrets:
+      GFP_API_KEY:
+        required: false
+env:
+  GFP_API_KEY: ${{ secrets.GFP_API_KEY }}
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  model-regression:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+        with:
+          python-version: "3.12"
+      - name: Install dependencies
+        run: make install
+      - name: Run model regression tests
+        env:
+          PYTEST_ADDOPTS: "-k model --tb=short"
+        run: |
+          output=$(make test 2>&1) && exit 0
+          # make wraps pytest exit-code 5 (no tests collected) into 2.
+          # If every pytest invocation deselected all tests, treat as pass.
+          if echo "$output" | grep -qE '/ 0 selected|no tests ran'; then
+            echo "No model tests found — skipping"
+            exit 0
+          fi
+          echo "$output"
+          exit 1
+      - name: Upload difftest artifacts
+        if: failure()
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: difftest-report-model_regression
+          path: test_diffs/
+          if-no-files-found: ignore
+          retention-days: 14

--- a/.github/workflows/test_coverage.yml
+++ b/.github/workflows/test_coverage.yml
@@ -1,0 +1,51 @@
+name: Test Coverage
+on:
+  workflow_call:
+    secrets:
+      GFP_API_KEY:
+        required: false
+env:
+  GFP_API_KEY: ${{ secrets.GFP_API_KEY }}
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+        with:
+          python-version: "3.12"
+      - name: Install dependencies
+        run: make install
+      - name: Detect package name
+        id: pkg
+        run: |
+          pkg=$(uv run python -c "
+          import tomllib
+          with open('pyproject.toml', 'rb') as f:
+              cfg = tomllib.load(f)
+          module = cfg.get('tool', {}).get('gdsfactoryplus', {}).get('pdk', {}).get('name', '')
+          print(module.split('.')[0] if module else '')
+          ")
+          echo "name=$pkg" >> "$GITHUB_OUTPUT"
+      - name: Run tests with coverage
+        env:
+          PYTEST_ADDOPTS: "--cov=${{ steps.pkg.outputs.name }} --cov-report=term-missing --cov-report=xml --cov-append -q"
+        run: make test
+      - name: Write summary
+        if: always()
+        run: |
+          uv run python -c "
+          import xml.etree.ElementTree as ET, os
+          try:
+              tree = ET.parse('coverage.xml')
+              rate = float(tree.getroot().attrib.get('line-rate', 0)) * 100
+              summary = os.environ.get('GITHUB_STEP_SUMMARY', '/dev/null')
+              with open(summary, 'a') as f:
+                  f.write(f'## Test Coverage\n\nLine coverage: {rate:.1f}%\n')
+              print(f'Coverage: {rate:.1f}%')
+          except Exception as e:
+              print(f'Could not parse coverage: {e}')
+          "

--- a/.github/workflows/update_badges.yml
+++ b/.github/workflows/update_badges.yml
@@ -1,0 +1,149 @@
+name: Update Badges
+on:
+  workflow_call:
+    secrets:
+      GFP_API_KEY:
+        required: false
+env:
+  GFP_API_KEY: ${{ secrets.GFP_API_KEY }}
+permissions:
+  contents: write
+  issues: read
+  pull-requests: read
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  badges:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+        with:
+          python-version: "3.12"
+      - name: Install dependencies
+        run: make install
+
+      - name: Detect package name
+        id: pkg
+        run: |
+          pkg=$(uv run python -c "
+          import tomllib
+          with open('pyproject.toml', 'rb') as f:
+              cfg = tomllib.load(f)
+          module = cfg.get('tool', {}).get('gdsfactoryplus', {}).get('pdk', {}).get('name', '')
+          print(module.split('.')[0] if module else '')
+          ")
+          echo "name=$pkg" >> "$GITHUB_OUTPUT"
+          echo "module=$(uv run python -c "
+          import tomllib
+          with open('pyproject.toml', 'rb') as f:
+              cfg = tomllib.load(f)
+          print(cfg.get('tool', {}).get('gdsfactoryplus', {}).get('pdk', {}).get('name', ''))
+          ")" >> "$GITHUB_OUTPUT"
+
+      - name: Compute test coverage
+        run: make test
+        continue-on-error: true
+        env:
+          PYTEST_ADDOPTS: "--cov=${{ steps.pkg.outputs.name }} --cov-report=xml --cov-append -q"
+
+      - name: Generate all badges
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PDK_MODULE: ${{ steps.pkg.outputs.module }}
+        run: |
+          mkdir -p badges
+          uv run python - <<'PYEOF'
+          import importlib, os, subprocess, xml.etree.ElementTree as ET
+          from pathlib import Path
+
+          SVG_TEMPLATE = """\
+          <svg xmlns="http://www.w3.org/2000/svg" width="{width}" height="20">
+            <linearGradient id="b" x2="0" y2="100%">
+              <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+              <stop offset="1" stop-opacity=".1"/>
+            </linearGradient>
+            <clipPath id="a">
+              <rect width="{width}" height="20" rx="3" fill="#fff"/>
+            </clipPath>
+            <g clip-path="url(#a)">
+              <rect width="{label_w}" height="20" fill="#555"/>
+              <rect x="{label_w}" width="{value_w}" height="20" fill="{color}"/>
+              <rect width="{width}" height="20" fill="url(#b)"/>
+            </g>
+            <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+              <text x="{label_x}" y="15" fill="#010101" fill-opacity=".3">{label}</text>
+              <text x="{label_x}" y="14">{label}</text>
+              <text x="{value_x}" y="15" fill="#010101" fill-opacity=".3">{value}</text>
+              <text x="{value_x}" y="14">{value}</text>
+            </g>
+          </svg>"""
+
+          def make_badge(label, value, color, filename):
+              label_w = len(label) * 6.5 + 12
+              value_w = len(value) * 6.5 + 12
+              width = label_w + value_w
+              svg = SVG_TEMPLATE.format(
+                  width=int(width), label_w=int(label_w), value_w=int(value_w),
+                  label_x=int(label_w / 2), value_x=int(label_w + value_w / 2),
+                  color=color, label=label, value=value,
+              )
+              Path(f"badges/{filename}").write_text(svg)
+              print(f"  {filename}: {label} = {value}")
+
+          # --- Test Coverage ---
+          try:
+              tree = ET.parse("coverage.xml")
+              rate = float(tree.getroot().attrib.get("line-rate", 0)) * 100
+          except Exception:
+              rate = 0
+          color = "#4c1" if rate >= 80 else ("#dfb317" if rate >= 60 else "#e05d44")
+          make_badge("coverage", f"{rate:.0f}%", color, "coverage.svg")
+
+          # --- Model Coverage ---
+          pdk_module = os.environ.get("PDK_MODULE", "")
+          try:
+              mod = importlib.import_module(pdk_module)
+              pdk = mod.PDK
+              pdk.activate()
+              cells = pdk.cells
+              models = getattr(pdk, "models", {}) or {}
+              total = len(cells)
+              with_model = len(set(cells) & set(models))
+              model_pct = (with_model / total * 100) if total else 0
+          except Exception as e:
+              print(f"  model coverage error: {e}")
+              model_pct = 0
+          color = "#4c1" if model_pct >= 80 else ("#dfb317" if model_pct >= 40 else "#e05d44")
+          make_badge("models", f"{model_pct:.0f}%", color, "model_coverage.svg")
+
+          # --- Open Issues & PRs ---
+          repo = os.environ.get("GITHUB_REPOSITORY", "")
+          def gh_count(query):
+              try:
+                  r = subprocess.run(
+                      ["gh", "api", f"search/issues?q=repo:{repo}+{query}&per_page=1",
+                       "--jq", ".total_count"],
+                      capture_output=True, text=True, check=True,
+                  )
+                  return int(r.stdout.strip())
+              except Exception:
+                  return 0
+
+          open_issues = gh_count("is:issue+is:open")
+          open_prs = gh_count("is:pr+is:open")
+          make_badge("issues", str(open_issues), "#4c1" if open_issues == 0 else ("#dfb317" if open_issues < 10 else "#e05d44"), "issues.svg")
+          make_badge("PRs", str(open_prs), "#4c1" if open_prs == 0 else ("#dfb317" if open_prs < 10 else "#e05d44"), "prs.svg")
+          PYEOF
+
+      - name: Commit badges
+        if: github.ref == 'refs/heads/main'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add badges/
+          if ! git diff --staged --quiet; then
+            git commit -m "update metric badges [skip ci]"
+            git push origin HEAD:main
+          fi

--- a/templates/.github/workflows/model_coverage.yml
+++ b/templates/.github/workflows/model_coverage.yml
@@ -1,0 +1,11 @@
+name: Model Coverage
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  model-coverage:
+    uses: doplaydo/pdk-ci-workflow/.github/workflows/model_coverage.yml@main
+    secrets: inherit

--- a/templates/.github/workflows/model_regression.yml
+++ b/templates/.github/workflows/model_regression.yml
@@ -1,0 +1,11 @@
+name: Model Regression
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  model-regression:
+    uses: doplaydo/pdk-ci-workflow/.github/workflows/model_regression.yml@main
+    secrets: inherit

--- a/templates/.github/workflows/test_coverage.yml
+++ b/templates/.github/workflows/test_coverage.yml
@@ -1,0 +1,11 @@
+name: Test Coverage
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  coverage:
+    uses: doplaydo/pdk-ci-workflow/.github/workflows/test_coverage.yml@main
+    secrets: inherit

--- a/templates/.github/workflows/update_badges.yml
+++ b/templates/.github/workflows/update_badges.yml
@@ -1,0 +1,12 @@
+name: Update Badges
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+jobs:
+  badges:
+    uses: doplaydo/pdk-ci-workflow/.github/workflows/update_badges.yml@main
+    secrets: inherit


### PR DESCRIPTION
## Summary

Add 4 new reusable workflows + caller templates:

| Workflow | Purpose |
|----------|---------|
| `model_coverage.yml` | Reports fraction of cells with an associated model |
| `model_regression.yml` | Runs `make test` filtered to `-k model`, handles repos with no model tests (exit code 5) |
| `test_coverage.yml` | Runs `make test` with `--cov=<pkg>` pinned to the package (not bare `--cov`) |
| `update_badges.yml` | Generates 4 SVG badges (coverage %, models %, open issues, open PRs) and commits to `badges/` |

All workflows **auto-detect** the PDK module and package name from `pyproject.toml` `[tool.gdsfactoryplus.pdk]` — no per-repo configuration needed.

Follows the same patterns as existing workflows:
- `workflow_call` trigger with optional `GFP_API_KEY` secret
- Pinned action SHAs matching `drc.yml` / `test_code.yml`
- Concurrency groups
- Difftest artifact uploads on failure

## Test plan

- [ ] Merge this, then test by pointing one PDK repo's caller workflows at `@main`
- [ ] Verify model_coverage, model_regression, test_coverage all pass
- [ ] Verify update_badges generates and commits SVGs to `badges/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)