### PR TITLE
fix: push badges to badges branch instead of main

### DIFF
--- a/.github/workflows/update_badges.yml
+++ b/.github/workflows/update_badges.yml
@@ -137,13 +137,22 @@ jobs:
           make_badge("PRs", str(open_prs), "#4c1" if open_prs == 0 else ("#dfb317" if open_prs < 10 else "#e05d44"), "prs.svg")
           PYEOF
 
-      - name: Commit badges
+      - name: Push badges to badges branch
         if: github.ref == 'refs/heads/main'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add badges/
-          if ! git diff --staged --quiet; then
-            git commit -m "update metric badges [skip ci]"
-            git push origin HEAD:main
-          fi
+
+          tmp=$(mktemp -d)
+          cp badges/*.svg "$tmp/"
+
+          git fetch origin badges 2>/dev/null && git checkout badges || {
+            git checkout --orphan badges
+            git rm -rf . 2>/dev/null || true
+          }
+
+          cp "$tmp"/*.svg .
+          git add *.svg
+          git diff --cached --quiet && echo "No badge changes" && exit 0
+          git commit -m "Update metric badges [skip ci]"
+          git push origin badges


### PR DESCRIPTION
## Summary

Repos with branch protection reject `git push origin HEAD:main`. Push badge SVGs to an orphan `badges` branch instead — this matches the README badge URLs which already reference `raw/badges/`.

## Test plan

- [ ] Trigger `update_badges` on a protected repo (e.g. qci)
- [ ] Verify badges branch is created with SVG files
- [ ] Confirm README badges render

🤖 Generated with [Claude Code](https://claude.com/claude-code)