### PR TITLE
fix: show 'failing' on DRC badge when DRC step fails

### DIFF
--- a/.github/workflows/drc.yml
+++ b/.github/workflows/drc.yml
@@ -42,8 +42,13 @@ jobs:
       - name: Create and commit DRC badge
         if: always()
         run: |
-          errors=$(grep -c '<item>' build/lyrdb/all_cells.lyrdb) || errors=0
-          if [ "$errors" = "0" ]; then color="#4c1"; else color="#e05d44"; fi
+          if [ -f build/lyrdb/all_cells.lyrdb ]; then
+            errors=$(grep -c '<item>' build/lyrdb/all_cells.lyrdb) || errors=0
+            if [ "$errors" = "0" ]; then color="#4c1"; else color="#e05d44"; fi
+          else
+            errors="failing"
+            color="#e05d44"
+          fi
           mkdir -p badges
           cat > badges/drc.svg << 'SVGEOF'
           <svg xmlns="http://www.w3.org/2000/svg" width="106" height="20" role="img" aria-label="DRC errors: PLACEHOLDER">


### PR DESCRIPTION
## Summary

When the DRC step fails (build error, missing file, etc.), the lyrdb file doesn't exist. Previously this fell through to `errors=0`, showing a green "0 errors" badge — misleading.

Now: if the lyrdb file is missing, the badge shows "failing" in red.

## Test plan

- [ ] DRC passes → badge shows error count (e.g. "0" green, "3" red)
- [ ] DRC fails → badge shows "failing" in red

🤖 Generated with [Claude Code](https://claude.com/claude-code)