### PR TITLE
fix: detect xdist zero-items in model regression skip

### DIFF
--- a/.github/workflows/model_regression.yml
+++ b/.github/workflows/model_regression.yml
@@ -26,7 +26,7 @@ jobs:
           output=$(make test 2>&1) && exit 0
           # make wraps pytest exit-code 5 (no tests collected) into 2.
           # If every pytest invocation deselected all tests, treat as pass.
-          if echo "$output" | grep -qE '/ 0 selected|no tests ran'; then
+          if echo "$output" | grep -qE '/ 0 selected|no tests ran|\[0 items\]'; then
             echo "No model tests found — skipping"
             exit 0
           fi


### PR DESCRIPTION
## Summary
- The model regression workflow's skip-detection grep doesn't match pytest-xdist's output format (`N workers [0 items]`), causing PDKs without model tests (like skywater130) to fail the check
- Adds `\[0 items\]` to the grep pattern alongside the existing `/ 0 selected` and `no tests ran` patterns

## Context
Fixes the blocked merge on gdsfactory/skywater130#169 and the same failure on main.

## Test plan
- [ ] After merge, re-run model-regression on skywater130 PR #169 — should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)