### PR TITLE
ci: skip docs build and claude review for dependabot PRs

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -13,6 +13,7 @@ permissions:
   id-token: write
 jobs:
   review:
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- Skip Claude PR review on Dependabot PRs

## Test plan
- [ ] Verify Dependabot PRs no longer trigger docs build or Claude review
- [ ] Verify regular PRs still trigger all jobs normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)