### PR TITLE
fix: retry badge push on non-fast-forward rejection

### DIFF
--- a/.github/workflows/drc.yml
+++ b/.github/workflows/drc.yml
@@ -84,4 +84,11 @@ jobs:
           git add drc.svg
           git diff --cached --quiet && echo "No DRC badge changes" && exit 0
           git commit -m "Update DRC badge [skip ci]"
-          git push origin badges
+
+          # Retry push with rebase in case another workflow updated badges concurrently
+          for i in 1 2 3; do
+            git push origin badges && break
+            echo "Push failed (attempt $i), rebasing..."
+            git fetch origin badges
+            git rebase origin/badges
+          done

--- a/.github/workflows/update_badges.yml
+++ b/.github/workflows/update_badges.yml
@@ -155,4 +155,11 @@ jobs:
           git add *.svg
           git diff --cached --quiet && echo "No badge changes" && exit 0
           git commit -m "Update metric badges [skip ci]"
-          git push origin badges
+
+          # Retry push with rebase in case another workflow updated badges concurrently
+          for i in 1 2 3; do
+            git push origin badges && break
+            echo "Push failed (attempt $i), rebasing..."
+            git fetch origin badges
+            git rebase origin/badges
+          done


### PR DESCRIPTION
## Summary

- Add retry loop with fetch + rebase (up to 3 attempts) to both `drc.yml` and `update_badges.yml` badge push steps
- Fixes `non-fast-forward` rejection when DRC and update_badges workflows push to the `badges` branch concurrently

## Context

When a push to `main` triggers both `drc.yml` and `update_badges.yml`, they both try to push to the `badges` branch. The second one fails with:
```
! [rejected] badges -> badges (non-fast-forward)
```

## Test plan

- [ ] Trigger both DRC and update_badges workflows concurrently on a repo
- [ ] Verify both complete successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)