### PR TITLE
fix: properly checkout remote badges branch before pushing

### DIFF
--- a/.github/workflows/drc.yml
+++ b/.github/workflows/drc.yml
@@ -75,20 +75,20 @@ jobs:
           tmp=$(mktemp -d)
           cp badges/drc.svg "$tmp/"
 
-          git fetch origin badges 2>/dev/null && git checkout badges || {
+          # Clean working tree so branch checkout succeeds
+          git clean -fdx
+          git checkout -f .
+
+          git fetch origin badges 2>/dev/null
+          if git rev-parse --verify origin/badges >/dev/null 2>&1; then
+            git checkout -f -B badges origin/badges
+          else
             git checkout --orphan badges
             git rm -rf . 2>/dev/null || true
-          }
+          fi
 
           cp "$tmp"/drc.svg .
           git add drc.svg
           git diff --cached --quiet && echo "No DRC badge changes" && exit 0
           git commit -m "Update DRC badge [skip ci]"
-
-          # Retry push with rebase in case another workflow updated badges concurrently
-          for i in 1 2 3; do
-            git push origin badges && break
-            echo "Push failed (attempt $i), rebasing..."
-            git fetch origin badges
-            git rebase origin/badges
-          done
+          git push origin badges

--- a/.github/workflows/update_badges.yml
+++ b/.github/workflows/update_badges.yml
@@ -146,20 +146,20 @@ jobs:
           tmp=$(mktemp -d)
           cp badges/*.svg "$tmp/"
 
-          git fetch origin badges 2>/dev/null && git checkout badges || {
+          # Clean working tree so branch checkout succeeds
+          git clean -fdx
+          git checkout -f .
+
+          git fetch origin badges 2>/dev/null
+          if git rev-parse --verify origin/badges >/dev/null 2>&1; then
+            git checkout -f -B badges origin/badges
+          else
             git checkout --orphan badges
             git rm -rf . 2>/dev/null || true
-          }
+          fi
 
           cp "$tmp"/*.svg .
           git add *.svg
           git diff --cached --quiet && echo "No badge changes" && exit 0
           git commit -m "Update metric badges [skip ci]"
-
-          # Retry push with rebase in case another workflow updated badges concurrently
-          for i in 1 2 3; do
-            git push origin badges && break
-            echo "Push failed (attempt $i), rebasing..."
-            git fetch origin badges
-            git rebase origin/badges
-          done
+          git push origin badges


### PR DESCRIPTION
## Summary

- Clean working tree (`git clean -fdx && git checkout -f .`) before switching to badges branch
- Use `git checkout -f -B badges origin/badges` to force-reset local branch to match remote
- Removes the broken retry-with-rebase approach that failed on orphan commit conflicts

## Problem

The previous `git fetch && git checkout badges || orphan` pattern silently fell to orphan mode when checkout failed due to dirty working tree (build artifacts from `make install` and `make test`). This created a root commit that:
1. Conflicted with the remote badges branch on push (non-fast-forward)
2. Could not be rebased because both commits were roots modifying `drc.svg`

## Test plan

- [ ] Trigger `update_badges` on a repo with existing `badges` branch containing `drc.svg`
- [ ] Verify coverage, models, issues, PRs SVGs are added alongside existing `drc.svg`
- [ ] Trigger DRC and update_badges concurrently — verify both succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)