### PR TITLE
Ignore jupyter-book in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: monthly
+    ignore:
+      - dependency-name: "jupyter-book"
 
   - package-ecosystem: github-actions
     cooldown:

--- a/templates/.github/dependabot.yml
+++ b/templates/.github/dependabot.yml
@@ -8,6 +8,7 @@ updates:
       interval: monthly
     ignore:
       - dependency-name: "doplaydo/*"
+      - dependency-name: "jupyter-book"
 
   - package-ecosystem: github-actions
     cooldown:


### PR DESCRIPTION
## Summary
- Add jupyter-book to dependabot ignore list to prevent unnecessary update PRs