### PR TITLE
fix: use git clean -fd and add push retry loop

### DIFF
--- a/.github/workflows/drc.yml
+++ b/.github/workflows/drc.yml
@@ -75,20 +75,25 @@ jobs:
           tmp=$(mktemp -d)
           cp badges/drc.svg "$tmp/"
 
-          # Clean working tree so branch checkout succeeds
-          git clean -fdx
+          # Clean untracked files so branch checkout succeeds
+          git clean -fd
           git checkout -f .
 
-          git fetch origin badges 2>/dev/null
-          if git rev-parse --verify origin/badges >/dev/null 2>&1; then
-            git checkout -f -B badges origin/badges
-          else
-            git checkout --orphan badges
-            git rm -rf . 2>/dev/null || true
-          fi
+          for attempt in 1 2 3; do
+            git fetch origin badges 2>/dev/null
+            if git rev-parse --verify origin/badges >/dev/null 2>&1; then
+              git checkout -f -B badges origin/badges
+            else
+              git checkout --orphan badges
+              git rm -rf . 2>/dev/null || true
+            fi
 
-          cp "$tmp"/drc.svg .
-          git add drc.svg
-          git diff --cached --quiet && echo "No DRC badge changes" && exit 0
-          git commit -m "Update DRC badge [skip ci]"
-          git push origin badges
+            cp "$tmp"/drc.svg .
+            git add drc.svg
+            git diff --cached --quiet && echo "No DRC badge changes" && exit 0
+            git commit -m "Update DRC badge [skip ci]"
+            git push origin badges && exit 0
+            echo "Push failed (attempt $attempt), retrying..."
+            sleep 5
+          done
+          echo "All push attempts failed" && exit 1

--- a/.github/workflows/update_badges.yml
+++ b/.github/workflows/update_badges.yml
@@ -146,20 +146,25 @@ jobs:
           tmp=$(mktemp -d)
           cp badges/*.svg "$tmp/"
 
-          # Clean working tree so branch checkout succeeds
-          git clean -fdx
+          # Clean untracked files so branch checkout succeeds
+          git clean -fd
           git checkout -f .
 
-          git fetch origin badges 2>/dev/null
-          if git rev-parse --verify origin/badges >/dev/null 2>&1; then
-            git checkout -f -B badges origin/badges
-          else
-            git checkout --orphan badges
-            git rm -rf . 2>/dev/null || true
-          fi
+          for attempt in 1 2 3; do
+            git fetch origin badges 2>/dev/null
+            if git rev-parse --verify origin/badges >/dev/null 2>&1; then
+              git checkout -f -B badges origin/badges
+            else
+              git checkout --orphan badges
+              git rm -rf . 2>/dev/null || true
+            fi
 
-          cp "$tmp"/*.svg .
-          git add *.svg
-          git diff --cached --quiet && echo "No badge changes" && exit 0
-          git commit -m "Update metric badges [skip ci]"
-          git push origin badges
+            cp "$tmp"/*.svg .
+            git add *.svg
+            git diff --cached --quiet && echo "No badge changes" && exit 0
+            git commit -m "Update metric badges [skip ci]"
+            git push origin badges && exit 0
+            echo "Push failed (attempt $attempt), retrying..."
+            sleep 5
+          done
+          echo "All push attempts failed" && exit 1


### PR DESCRIPTION
## Summary

Follow-up to #82, addressing review comments:

- Use `git clean -fd` instead of `-fdx` to avoid removing gitignored files (`.venv`, build caches)
- Add retry loop (3 attempts): on push failure, re-fetch remote badges branch, re-checkout from remote, re-apply SVGs, and retry — handles the race when DRC and update_badges push concurrently

## Test plan

- [ ] Trigger DRC and update_badges concurrently on a repo
- [ ] Verify both succeed (second one retries and pushes on top of first)

🤖 Generated with [Claude Code](https://claude.com/claude-code)