### PR TITLE
feat: add severity markers to claude reviewer prompt

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -44,7 +44,8 @@ jobs:
 
             Output format — ultra-terse, one line per issue:
             - Drop articles (a/an/the), filler words, pleasantries, and preamble.
-            - Each issue: `[file:line] problem. fix.`
+            - Prefix each issue with a severity marker: 🔴 blocking bug introduced by this PR · 🟡 nit/non-blocking · 🟣 pre-existing issue not introduced by this PR.
+            - Each issue: `🔴/🟡/🟣 [file:line] problem. fix.`
             - No summaries. No "Overall, ...". No positive remarks.
 
             Use `gh pr comment` for top-level feedback.

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -44,7 +44,7 @@ jobs:
 
             Output format — ultra-terse, one line per issue:
             - Drop articles (a/an/the), filler words, pleasantries, and preamble.
-            - Prefix each issue with a severity marker: 🔴 blocking bug introduced by this PR · 🟡 nit/non-blocking · 🟣 pre-existing issue not introduced by this PR.
+            - Prefix each issue with a severity marker: 🔴 bug that should be fixed before merging · 🟡 minor issue, worth fixing but not blocking · 🟣 bug in codebase not introduced by this PR.
             - Each issue: `🔴/🟡/🟣 [file:line] problem. fix.`
             - No summaries. No "Overall, ...". No positive remarks.
 


### PR DESCRIPTION
Closes #85

## Change

Two lines added to the output format section of the Claude reviewer prompt — no other changes.

```
- Prefix each issue with a severity marker: 🔴 blocking bug introduced by this PR · 🟡 nit/non-blocking · 🟣 pre-existing issue not introduced by this PR.
- Each issue: `🔴/🟡/🟣 [file:line] problem. fix.`
```

Scheme mirrors the [Claude Code managed review service](https://code.claude.com/docs/en/code-review) — same three markers, same semantics. No prompt rewrite; all existing instructions preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)