### PR TITLE
fix: check-no-raw-layers false positives for coordinate tuples

### DIFF
--- a/hooks/check_no_raw_layers.py
+++ b/hooks/check_no_raw_layers.py
@@ -93,8 +93,12 @@ class RawLayerTupleFinder(ast.NodeVisitor):
     def _is_layer_context(self) -> bool:
         """Return True if the current kwarg context looks like a layer argument."""
         if self._kwarg_name is None:
-            # Not inside a keyword argument at all — flag conservatively.
-            return True
+            # Not inside a keyword argument — could be a coordinate tuple
+            # (e.g. `c.center = (0, 0)`, `inst.move((0, 0))`), a size, or some
+            # other non-layer value. Only flag tuples that appear in an
+            # explicit layer kwarg; positional/attribute-assignment contexts
+            # are too ambiguous to flag reliably.
+            return False
         kwarg = self._kwarg_name
         return (
             kwarg in _LAYER_KWARG_NAMES


### PR DESCRIPTION
Closes #73

## Problem

`check-no-raw-layers` treats any `(int, int)` tuple outside a kwarg as a potential raw layer. This produces false positives for coordinate tuples that happen to have integer components — reported in `qpdk` for cases like:

```python
c.center = (0, 0)        # attribute assignment
inst.move((0, 0))        # positional arg to coordinate method
```

Root cause: `_is_layer_context()` returned `True` when `_kwarg_name is None` (anything outside a keyword argument).

## Fix

Flip the default. Only flag tuples that appear in an **explicit layer kwarg** (`layer=`, `bbox_layers=`, `*_layer=`, `*_layers=`). Positional and attribute-assignment contexts are too ambiguous to flag reliably.

```diff
-        if self._kwarg_name is None:
-            # Not inside a keyword argument at all — flag conservatively.
-            return True
+        if self._kwarg_name is None:
+            # Not inside a keyword argument — could be a coordinate tuple
+            # (e.g. `c.center = (0, 0)`, `inst.move((0, 0))`), a size, or some
+            # other non-layer value. Only flag tuples that appear in an
+            # explicit layer kwarg; positional/attribute-assignment contexts
+            # are too ambiguous to flag reliably.
+            return False
```

## Trade-off

**Catches:** all common cases — `gf.Component(layer=(1, 0))`, `foo(bbox_layers=[(1, 0)])`, any `*_layer=` kwarg.

**Misses:** raw layers passed positionally, e.g. `add_polygon(pts, (1, 0))`. In practice the gf public API takes layers as kwargs, so this is theoretical. If real cases appear, the hook can be upgraded to track known layer-taking positional APIs.

## Verification

Smoke test with reporter's patterns + layer kwargs:

```
COORDS (should pass): errors=0
LAYERS (should flag): errors=3
  test.py:3 raw layer tuple (1, 0) — use LAYER.XXX constant instead
  test.py:4 raw layer tuple (2, 0) — use LAYER.XXX constant instead
  test.py:5 raw layer tuple (3, 0) — use LAYER.XXX constant instead
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)