### PR TITLE
add check-template-drift hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -144,6 +144,17 @@
     Checks version strings match across pyproject.toml [project].version,
     [tool.tbump.version].current, __init__.py __version__, and README.md.
 
+- id: check-template-drift
+  name: Check .github template drift
+  entry: check_template_drift
+  language: python
+  always_run: true
+  pass_filenames: false
+  description: >
+    Enforces PDK repo .github/ files match the canonical templates in
+    pdk-ci-workflow. Ruff-style auto-fix: on drift, rewrites local file
+    from template and exits 1; second run exits 0.
+
 # =============================================================================
 # Third-party wrapper hooks
 #

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This repository provides reusable automation tooling for Process Design Kit (PDK
 - Standardized testing, linting, and type checking across all PDKs
 - Automated documentation builds and deployments
 - AI-powered code reviews via Claude
-- 14 pre-commit hooks enforcing PDK structural compliance
+- 15 pre-commit hooks enforcing PDK structural compliance
 - Semantic versioning and automated release notes
 - Template files for onboarding new PDK repos
 
@@ -21,7 +21,7 @@ This repository provides reusable automation tooling for Process Design Kit (PDK
 This repository provides four complementary automation patterns:
 
 - **Reusable GitHub Actions Workflows** - Complete CI/CD jobs for testing, docs, releases, and code review
-- **Pre-commit Hooks** - 14 PDK compliance checks plus 10 third-party tool wrappers (ruff, codespell, etc.) with centrally controlled versions
+- **Pre-commit Hooks** - 15 PDK compliance checks plus 10 third-party tool wrappers (ruff, codespell, etc.) with centrally controlled versions
 - **Templates** - Reference configuration files for onboarding new PDK repos
 - **Composite Actions** - Shared step sequences for flexible workflow composition (in development)
 
@@ -140,7 +140,7 @@ PDK repos should have these secrets configured (passed automatically via `secret
 
 Two types of hooks are defined in `.pre-commit-hooks.yaml`:
 
-- **14 PDK compliance hooks** (`hooks/*.py`) — validate repo structure, cells, tech, tests, etc.
+- **15 PDK compliance hooks** (`hooks/*.py`) — validate repo structure, cells, tech, tests, etc.
 - **10 third-party wrapper hooks** — ruff, codespell, nbstripout, trailing-whitespace, etc. with versions pinned via `additional_dependencies` so they're controlled centrally
 
 All hooks use `always_run: true` and `pass_filenames: false` (repo-level checks). Errors = failure, warnings = pass but alert.
@@ -175,6 +175,7 @@ See [`hooks/README.md`](hooks/README.md) for detailed documentation.
 | `check-makefile-targets` | Required targets (install, test) and recommended targets (docs, build, test-force, update-pre, dev) |
 | `check-workflows` | `.github/workflows/` has test_code.yml with pre-commit and test jobs |
 | `check-precommit-config` | `.pre-commit-config.yaml` includes required hooks (trailing-whitespace, end-of-file-fixer, ruff or ruff-lint, ruff-format) |
+| `check-template-drift` | `.github/dependabot.yml`, `.github/release-drafter.yml`, and `.github/workflows/*.yml` thin callers match upstream templates. Auto-fixes drift. |
 
 #### Multi-band
 
@@ -285,7 +286,7 @@ pdk-ci-workflow/
 │   └── README.md
 ├── hooks/                  # Pre-commit hook implementations
 │   ├── _utils.py           # Shared utilities (TOML/YAML, AST, CheckResult)
-│   ├── check_*.py          # Individual hook scripts (14 total)
+│   ├── check_*.py          # Individual hook scripts (15 total)
 │   └── README.md
 ├── templates/              # Config templates synced to PDK repos
 │   ├── .pre-commit-config.yaml

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -4,7 +4,7 @@ Pre-commit hook scripts for PDK template compliance. These are referenced by `.p
 
 Each hook is a self-contained Python script that validates some aspect of a PDK repository's structure and configuration. Hooks use **errors** for required items (fail the hook) and **warnings** for recommended items (print but pass).
 
-## Available Hooks (14)
+## Available Hooks (15)
 
 ### Project Structure
 
@@ -33,6 +33,7 @@ Each hook is a self-contained Python script that validates some aspect of a PDK 
 | `check-makefile-targets` | `check_makefile_targets.py` | Required targets: install, test. Recommended: docs, build, test-force, update-pre, dev. Content checks: uv sync in install, pytest in test |
 | `check-workflows` | `check_workflows.py` | `.github/workflows/` has test_code.yml (or test.yml) with pre-commit job and test job; recommends release.yml |
 | `check-precommit-config` | `check_precommit_config.py` | `.pre-commit-config.yaml` includes required hooks (end-of-file-fixer, trailing-whitespace, ruff or ruff-lint, ruff-format) and recommended hooks (nbstripout, codespell) |
+| `check-template-drift` | `check_template_drift.py` | Enforces `.github/dependabot.yml`, `.github/release-drafter.yml`, and `.github/workflows/*.yml` thin callers match upstream `templates/`. Ruff-style auto-fix: drift → rewrite + exit 1, re-run → exit 0. Skips missing files (sync only, no create). No-ops inside pdk-ci-workflow itself. |
 
 ### Multi-band
 

--- a/hooks/check_template_drift.py
+++ b/hooks/check_template_drift.py
@@ -16,7 +16,7 @@ from pathlib import Path
 
 import yaml
 
-from hooks._utils import CheckResult
+from hooks._utils import CheckResult, load_toml
 
 # Paths (relative to PDK repo root) that must match the upstream template of
 # the same relative path under `templates/` in pdk-ci-workflow.
@@ -59,11 +59,12 @@ def _diff(old: str, new: str, path: str) -> str:
 def _is_self_repo() -> bool:
     """Skip when running inside pdk-ci-workflow itself.
 
-    The canonical templates live at `templates/.github/` in this repo,
-    and `.github/` holds the REUSABLE source workflows (not thin callers).
-    Enforcing thin-caller content over source workflows would be destructive.
+    This repo's `.github/` holds REUSABLE source workflows (not thin callers),
+    so enforcing template content would clobber them. Identified by
+    `pyproject.toml` project name.
     """
-    return Path("templates/.github/dependabot.yml").is_file()
+    data = load_toml("pyproject.toml")
+    return bool(data and data.get("project", {}).get("name") == "ci-pdk-workflows")
 
 
 def main() -> int:
@@ -87,13 +88,13 @@ def main() -> int:
             result.warn(f"no canonical template shipped for {rel}")
             continue
 
-        src_text = src.read_text()
-        local_text = local.read_text()
+        src_text = src.read_text(encoding="utf-8")
+        local_text = local.read_text(encoding="utf-8")
 
         if _yaml_equal(src_text, local_text):
             continue
 
-        local.write_text(src_text)
+        local.write_text(src_text, encoding="utf-8")
         print(_diff(local_text, src_text, rel))
         result.error(f"rewrote {rel} from upstream template")
 

--- a/hooks/check_template_drift.py
+++ b/hooks/check_template_drift.py
@@ -37,11 +37,12 @@ TEMPLATES: list[str] = [
 
 
 def _yaml_equal(a: str, b: str) -> bool:
-    """Semantic YAML equality — ignores whitespace, quote-style, key order."""
-    try:
-        return yaml.safe_load(a) == yaml.safe_load(b)
-    except yaml.YAMLError:
-        return a == b
+    """Semantic YAML equality — ignores whitespace, quote-style, key order.
+
+    Raises yaml.YAMLError if either input fails to parse; caller decides how
+    to handle the fallback so it's never silent.
+    """
+    return yaml.safe_load(a) == yaml.safe_load(b)
 
 
 def _diff(old: str, new: str, path: str) -> str:
@@ -85,14 +86,22 @@ def main() -> int:
         for p in parts:
             src = src.joinpath(p)
         if not src.is_file():
-            result.warn(f"no canonical template shipped for {rel}")
+            result.error(f"no canonical template shipped for {rel}")
             continue
 
         src_text = src.read_text(encoding="utf-8")
         local_text = local.read_text(encoding="utf-8")
 
-        if _yaml_equal(src_text, local_text):
-            continue
+        try:
+            if _yaml_equal(src_text, local_text):
+                continue
+        except yaml.YAMLError as e:
+            result.warn(
+                f"{rel}: YAML parse failed ({e}); falling back to string "
+                "equality — whitespace/comment-only differences may trigger rewrite"
+            )
+            if src_text == local_text:
+                continue
 
         local.write_text(src_text, encoding="utf-8")
         print(_diff(local_text, src_text, rel))

--- a/hooks/check_template_drift.py
+++ b/hooks/check_template_drift.py
@@ -1,0 +1,104 @@
+"""Pre-commit hook: enforce .github files match upstream templates.
+
+Ruff-style auto-fix: on drift, rewrites local file from the canonical template
+shipped inside this package, then exits 1. Second run sees no drift, exits 0.
+
+Files to enforce are listed in TEMPLATES. Missing local files are skipped
+(hook syncs existing files, does not create new ones).
+"""
+
+from __future__ import annotations
+
+import difflib
+import sys
+from importlib.resources import files
+from pathlib import Path
+
+import yaml
+
+from hooks._utils import CheckResult
+
+# Paths (relative to PDK repo root) that must match the upstream template of
+# the same relative path under `templates/` in pdk-ci-workflow.
+TEMPLATES: list[str] = [
+    ".github/dependabot.yml",
+    ".github/release-drafter.yml",
+    ".github/workflows/claude-pr-review.yml",
+    ".github/workflows/drc.yml",
+    ".github/workflows/issue.yml",
+    ".github/workflows/model_coverage.yml",
+    ".github/workflows/model_regression.yml",
+    ".github/workflows/pages.yml",
+    ".github/workflows/release-drafter.yml",
+    ".github/workflows/test_code.yml",
+    ".github/workflows/test_coverage.yml",
+    ".github/workflows/update_badges.yml",
+]
+
+
+def _yaml_equal(a: str, b: str) -> bool:
+    """Semantic YAML equality — ignores whitespace, quote-style, key order."""
+    try:
+        return yaml.safe_load(a) == yaml.safe_load(b)
+    except yaml.YAMLError:
+        return a == b
+
+
+def _diff(old: str, new: str, path: str) -> str:
+    return "".join(
+        difflib.unified_diff(
+            old.splitlines(keepends=True),
+            new.splitlines(keepends=True),
+            fromfile=f"a/{path}",
+            tofile=f"b/{path}",
+            n=2,
+        )
+    )
+
+
+def _is_self_repo() -> bool:
+    """Skip when running inside pdk-ci-workflow itself.
+
+    The canonical templates live at `templates/.github/` in this repo,
+    and `.github/` holds the REUSABLE source workflows (not thin callers).
+    Enforcing thin-caller content over source workflows would be destructive.
+    """
+    return Path("templates/.github/dependabot.yml").is_file()
+
+
+def main() -> int:
+    result = CheckResult("check-template-drift")
+
+    if _is_self_repo():
+        return 0
+
+    root = files("templates")
+
+    for rel in TEMPLATES:
+        local = Path(rel)
+        if not local.exists():
+            continue
+
+        parts = rel.split("/")
+        src = root
+        for p in parts:
+            src = src.joinpath(p)
+        if not src.is_file():
+            result.warn(f"no canonical template shipped for {rel}")
+            continue
+
+        src_text = src.read_text()
+        local_text = local.read_text()
+
+        if _yaml_equal(src_text, local_text):
+            continue
+
+        local.write_text(src_text)
+        print(_diff(local_text, src_text, rel))
+        result.error(f"rewrote {rel} from upstream template")
+
+    return result.report()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/hooks/check_template_drift.py
+++ b/hooks/check_template_drift.py
@@ -14,8 +14,6 @@ import sys
 from importlib.resources import files
 from pathlib import Path
 
-import yaml
-
 from hooks._utils import CheckResult, load_toml
 
 # Paths (relative to PDK repo root) that must match the upstream template of
@@ -34,15 +32,6 @@ TEMPLATES: list[str] = [
     ".github/workflows/test_coverage.yml",
     ".github/workflows/update_badges.yml",
 ]
-
-
-def _yaml_equal(a: str, b: str) -> bool:
-    """Semantic YAML equality — ignores whitespace, quote-style, key order.
-
-    Raises yaml.YAMLError if either input fails to parse; caller decides how
-    to handle the fallback so it's never silent.
-    """
-    return yaml.safe_load(a) == yaml.safe_load(b)
 
 
 def _diff(old: str, new: str, path: str) -> str:
@@ -92,16 +81,8 @@ def main() -> int:
         src_text = src.read_text(encoding="utf-8")
         local_text = local.read_text(encoding="utf-8")
 
-        try:
-            if _yaml_equal(src_text, local_text):
-                continue
-        except yaml.YAMLError as e:
-            result.warn(
-                f"{rel}: YAML parse failed ({e}); falling back to string "
-                "equality — whitespace/comment-only differences may trigger rewrite"
-            )
-            if src_text == local_text:
-                continue
+        if src_text == local_text:
+            continue
 
         local.write_text(src_text, encoding="utf-8")
         print(_diff(local_text, src_text, rel))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ check_no_raw_layers = "hooks.check_no_raw_layers:main"
 check_no_main_in_cells = "hooks.check_no_main_in_cells:main"
 check_precommit_config = "hooks.check_precommit_config:main"
 check_version_sync = "hooks.check_version_sync:main"
+check_template_drift = "hooks.check_template_drift:main"
 
 [build-system]
 requires = ["setuptools>=68.0"]
@@ -31,4 +32,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.setuptools.packages.find]
 where = ["."]
-include = ["hooks*"]
+include = ["hooks*", "templates*"]
+
+[tool.setuptools.package-data]
+"templates" = [".github/**/*"]

--- a/templates/.pre-commit-config.yaml
+++ b/templates/.pre-commit-config.yaml
@@ -29,6 +29,7 @@ repos:
       - id: check-no-raw-layers
       - id: check-no-main-in-cells
       - id: check-precommit-config
+      - id: check-template-drift
       # Code quality (versions controlled by pdk-ci-workflow)
       - id: trailing-whitespace
       - id: end-of-file-fixer

--- a/templates/__init__.py
+++ b/templates/__init__.py
@@ -1,0 +1,1 @@
+"""Canonical PDK templates shipped as package data for hook enforcement."""


### PR DESCRIPTION
Closes #91
Closes #90

## What

New pre-commit hook `check-template-drift`. Enforces PDK repo `.github/` files match canonical templates. Ruff-style auto-fix.

## How

- Drift detected → rewrite local file from upstream template, exit 1
- Re-run → clean, exit 0
- Missing local file → skip (sync existing, don't create)
- Self-detects pdk-ci-workflow → no-op (source workflows ≠ thin callers)

## Enforced files

`.github/dependabot.yml`, `.github/release-drafter.yml`, all `.github/workflows/*.yml` thin callers. List in `hooks/check_template_drift.py::TEMPLATES`.

## Packaging

Templates ship as package data via new `templates/__init__.py` + `[tool.setuptools.package-data]`. Hook uses `importlib.resources` → no network at commit, version pinned by pre-commit `rev`.

## Test

```
# PDK repo with canonical templates → pass
python -m hooks.check_template_drift  # exit 0

# mangle a file → fix + fail
sed -i 's/monthly/weekly/' .github/dependabot.yml
python -m hooks.check_template_drift  # exit 1, file restored

# re-run → pass
python -m hooks.check_template_drift  # exit 0

# inside pdk-ci-workflow itself → skip
cd pdk-ci-workflow && python -m hooks.check_template_drift  # exit 0, no changes
```

All verified locally.

## Follow-up (not in this PR)

- Sync the 10 drifting PDKs + surface the 9 with missing file (see #91 evidence table)
- Add hook to `update_badges.yml` for dormant-repo self-healing
- Fix `customer_portal` `default: 7` typo (separate task)