### PR TITLE
Mark secrets as required in reusable workflows

### DIFF
--- a/.github/workflows/drc.yml
+++ b/.github/workflows/drc.yml
@@ -3,7 +3,7 @@ on:
   workflow_call:
     secrets:
       GFP_API_KEY:
-        required: false
+        required: true
 env:
   GFP_API_KEY: ${{ secrets.GFP_API_KEY }}
 permissions:

--- a/.github/workflows/model_coverage.yml
+++ b/.github/workflows/model_coverage.yml
@@ -3,7 +3,7 @@ on:
   workflow_call:
     secrets:
       GFP_API_KEY:
-        required: false
+        required: true
 env:
   GFP_API_KEY: ${{ secrets.GFP_API_KEY }}
 concurrency:

--- a/.github/workflows/model_regression.yml
+++ b/.github/workflows/model_regression.yml
@@ -3,7 +3,7 @@ on:
   workflow_call:
     secrets:
       GFP_API_KEY:
-        required: false
+        required: true
 env:
   GFP_API_KEY: ${{ secrets.GFP_API_KEY }}
 concurrency:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -3,9 +3,9 @@ on:
   workflow_call:
     secrets:
       GFP_API_KEY:
-        required: false
+        required: true
       SIMCLOUD_APIKEY:
-        required: false
+        required: true
 jobs:
   build-docs:
     if: github.event_name != 'pull_request' || github.event.pull_request.user.login != 'dependabot[bot]'

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -7,7 +7,7 @@ on:
   workflow_call:
     secrets:
       ANTHROPIC_API_KEY:
-        required: false
+        required: true
 permissions:
   contents: read
 jobs:

--- a/.github/workflows/test_code.yml
+++ b/.github/workflows/test_code.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     secrets:
       GFP_API_KEY:
-        required: false
+        required: true
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/test_coverage.yml
+++ b/.github/workflows/test_coverage.yml
@@ -3,7 +3,7 @@ on:
   workflow_call:
     secrets:
       GFP_API_KEY:
-        required: false
+        required: true
 env:
   GFP_API_KEY: ${{ secrets.GFP_API_KEY }}
 concurrency:

--- a/.github/workflows/update_badges.yml
+++ b/.github/workflows/update_badges.yml
@@ -3,7 +3,7 @@ on:
   workflow_call:
     secrets:
       GFP_API_KEY:
-        required: false
+        required: true
 env:
   GFP_API_KEY: ${{ secrets.GFP_API_KEY }}
 permissions:


### PR DESCRIPTION
## Summary

Marks `GFP_API_KEY`, `SIMCLOUD_APIKEY`, and `ANTHROPIC_API_KEY` as `required: true` in all reusable workflows. These are org-level secrets available to every PDK repo — marking them required means misconfigured repos fail fast instead of silently running with empty values.

## What changed

- `required: false` → `required: true` on all secret declarations in 8 reusable workflows
- **No template changes** — thin wrappers stay as-is with `secrets: inherit`, which already forwards all secrets

## Previous approach (replaced)

The original PR changed the thin wrapper templates to use explicit `GFP_API_KEY: ${{ secrets.GFP_API_KEY }}` forwarding instead of `secrets: inherit`. This was:
1. Redundant — `secrets: inherit` already forwards the key
2. A regression — dropped `SIMCLOUD_APIKEY` from pages.yml
3. Violating the architecture — templates are thin wrappers, don't modify them

The fix belongs in the reusable workflows, not the templates.

## Test plan
- [ ] Verify PDK repos with org-level secrets continue to work
- [ ] Verify repos missing required secrets get a clear error at workflow start

🤖 Generated with [Claude Code](https://claude.com/claude-code)