### PR TITLE
Add build_cell.py to check-template-drift with PDK-only filtering

### DIFF
--- a/hooks/check_template_drift.py
+++ b/hooks/check_template_drift.py
@@ -19,6 +19,7 @@ from hooks._utils import CheckResult, load_toml
 # Paths (relative to PDK repo root) that must match the upstream template of
 # the same relative path under `templates/` in pdk-ci-workflow.
 TEMPLATES: list[str] = [
+    "build_cell.py",
     ".github/dependabot.yml",
     ".github/release-drafter.yml",
     ".github/workflows/claude-pr-review.yml",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,4 +35,4 @@ where = ["."]
 include = ["hooks*", "templates*"]
 
 [tool.setuptools.package-data]
-"templates" = [".github/**/*"]
+"templates" = [".github/**/*", "build_cell.py"]

--- a/templates/build_cell.py
+++ b/templates/build_cell.py
@@ -1,0 +1,52 @@
+"""Build a cell and write it to build/gds/<cell_name>.gds.
+
+When cell_name is "all_cells", builds every PDK-owned cell that can be
+instantiated with default arguments and packs them into a single GDS.
+Cells from installed packages (site-packages / .venv) and cells that
+require positional arguments are skipped automatically.
+"""
+
+import inspect
+import sys
+from pathlib import Path
+
+from gdsfactoryplus.core.pdk import get_pdk, register_cells
+
+cell_name = sys.argv[1]
+Path("build/gds").mkdir(parents=True, exist_ok=True)
+register_cells()
+pdk = get_pdk()
+
+if cell_name == "all_cells":
+    import gdsfactory as gf
+
+    c = gf.Component("all_cells")
+    for name, func in sorted(pdk.cells.items()):
+        # Skip cells from installed packages (not PDK-owned)
+        try:
+            src = inspect.getfile(func)
+        except TypeError:
+            continue
+        if ".venv" in src or "site-packages" in src:
+            continue
+
+        # Skip cells that require positional arguments
+        sig = inspect.signature(func)
+        required = [
+            p
+            for p in sig.parameters.values()
+            if p.default is inspect.Parameter.empty
+            and p.kind not in (p.VAR_POSITIONAL, p.VAR_KEYWORD)
+        ]
+        if required:
+            print(f"Skipping {name}: requires arguments {[p.name for p in required]}")
+            continue
+
+        try:
+            c.add_ref(func())
+        except Exception as e:
+            print(f"Error instantiating cell {name}: {e}")
+    c.write_gds(f"build/gds/{cell_name}.gds")
+else:
+    c = pdk.cells[cell_name]()
+    c.write_gds(f"build/gds/{cell_name}.gds")


### PR DESCRIPTION
## Summary
- Adds canonical `templates/build_cell.py` that filters to PDK-owned cells when building `all_cells`, skipping site-packages sources and cells with required positional arguments
- Adds `build_cell.py` to `TEMPLATES` list in `check_template_drift.py`
- Includes `build_cell.py` in package data for `importlib.resources` access

## Test plan
- [ ] Verify `check-template-drift` detects stale `build_cell.py` in a PDK repo
- [ ] Verify DRC workflow builds only PDK cells when using the new template
- [ ] Verify existing PDK repos get auto-fixed on next pre-commit run

Fixes #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)