### PR TITLE
Update actions/upload-pages-artifact to v5

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           make docs
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5
         with:
           path: "./docs/_build/html/"
   deploy-docs:


### PR DESCRIPTION
Bump `actions/upload-pages-artifact` from v4 to v5 to avoid Node.js deprecation warnings on GitHub Actions runners, see https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/