### PR TITLE
Use uv run python shell for coverage and badge workflows

### DIFF
--- a/.github/workflows/model_coverage.yml
+++ b/.github/workflows/model_coverage.yml
@@ -20,8 +20,8 @@ jobs:
       - name: Install dependencies
         run: make install
       - name: Check model coverage
+        shell: uv run python {0}
         run: |
-          uv run python - <<'PYEOF'
           import importlib, os, tomllib
           from pathlib import Path
 
@@ -49,4 +49,3 @@ jobs:
               f.write(f"| Cells with model | {with_model} |\n")
               f.write(f"| Coverage | {pct:.1f}% |\n")
           print(f"Model coverage: {with_model}/{total} ({pct:.1f}%)")
-          PYEOF

--- a/.github/workflows/test_coverage.yml
+++ b/.github/workflows/test_coverage.yml
@@ -28,7 +28,7 @@ jobs:
               cfg = tomllib.load(f)
           module = cfg.get("tool", {}).get("gdsfactoryplus", {}).get("pdk", {}).get("name", "")
           pkg = module.split(".")[0] if module else ""
-          with open(os.environ["GITHUB_OUTPUT"], "a") as f:
+          with open(os.environ.get("GITHUB_OUTPUT", "/dev/null"), "a") as f:
               f.write(f"name={pkg}\n")
       - name: Run tests with coverage
         env:

--- a/.github/workflows/test_coverage.yml
+++ b/.github/workflows/test_coverage.yml
@@ -21,31 +21,30 @@ jobs:
         run: make install
       - name: Detect package name
         id: pkg
+        shell: uv run python {0}
         run: |
-          pkg=$(uv run python -c "
-          import tomllib
-          with open('pyproject.toml', 'rb') as f:
+          import tomllib, os
+          with open("pyproject.toml", "rb") as f:
               cfg = tomllib.load(f)
-          module = cfg.get('tool', {}).get('gdsfactoryplus', {}).get('pdk', {}).get('name', '')
-          print(module.split('.')[0] if module else '')
-          ")
-          echo "name=$pkg" >> "$GITHUB_OUTPUT"
+          module = cfg.get("tool", {}).get("gdsfactoryplus", {}).get("pdk", {}).get("name", "")
+          pkg = module.split(".")[0] if module else ""
+          with open(os.environ["GITHUB_OUTPUT"], "a") as f:
+              f.write(f"name={pkg}\n")
       - name: Run tests with coverage
         env:
           PYTEST_ADDOPTS: "--cov=${{ steps.pkg.outputs.name }} --cov-report=term-missing --cov-report=xml --cov-append -q"
         run: make test
       - name: Write summary
         if: always()
+        shell: uv run python {0}
         run: |
-          uv run python -c "
           import xml.etree.ElementTree as ET, os
           try:
-              tree = ET.parse('coverage.xml')
-              rate = float(tree.getroot().attrib.get('line-rate', 0)) * 100
-              summary = os.environ.get('GITHUB_STEP_SUMMARY', '/dev/null')
-              with open(summary, 'a') as f:
-                  f.write(f'## Test Coverage\n\nLine coverage: {rate:.1f}%\n')
-              print(f'Coverage: {rate:.1f}%')
+              tree = ET.parse("coverage.xml")
+              rate = float(tree.getroot().attrib.get("line-rate", 0)) * 100
+              summary = os.environ.get("GITHUB_STEP_SUMMARY", "/dev/null")
+              with open(summary, "a") as f:
+                  f.write(f"## Test Coverage\n\nLine coverage: {rate:.1f}%\n")
+              print(f"Coverage: {rate:.1f}%")
           except Exception as e:
-              print(f'Could not parse coverage: {e}')
-          "
+              print(f"Could not parse coverage: {e}")

--- a/.github/workflows/update_badges.yml
+++ b/.github/workflows/update_badges.yml
@@ -33,7 +33,7 @@ jobs:
               cfg = tomllib.load(f)
           module = cfg.get("tool", {}).get("gdsfactoryplus", {}).get("pdk", {}).get("name", "")
           name = module.split(".")[0] if module else ""
-          with open(os.environ["GITHUB_OUTPUT"], "a") as f:
+          with open(os.environ.get("GITHUB_OUTPUT", "/dev/null"), "a") as f:
               f.write(f"name={name}\n")
               f.write(f"module={module}\n")
 

--- a/.github/workflows/update_badges.yml
+++ b/.github/workflows/update_badges.yml
@@ -26,21 +26,16 @@ jobs:
 
       - name: Detect package name
         id: pkg
+        shell: uv run python {0}
         run: |
-          pkg=$(uv run python -c "
-          import tomllib
-          with open('pyproject.toml', 'rb') as f:
+          import tomllib, os
+          with open("pyproject.toml", "rb") as f:
               cfg = tomllib.load(f)
-          module = cfg.get('tool', {}).get('gdsfactoryplus', {}).get('pdk', {}).get('name', '')
-          print(module.split('.')[0] if module else '')
-          ")
-          echo "name=$pkg" >> "$GITHUB_OUTPUT"
-          echo "module=$(uv run python -c "
-          import tomllib
-          with open('pyproject.toml', 'rb') as f:
-              cfg = tomllib.load(f)
-          print(cfg.get('tool', {}).get('gdsfactoryplus', {}).get('pdk', {}).get('name', ''))
-          ")" >> "$GITHUB_OUTPUT"
+          module = cfg.get("tool", {}).get("gdsfactoryplus", {}).get("pdk", {}).get("name", "")
+          name = module.split(".")[0] if module else ""
+          with open(os.environ["GITHUB_OUTPUT"], "a") as f:
+              f.write(f"name={name}\n")
+              f.write(f"module={module}\n")
 
       - name: Compute test coverage
         run: make test
@@ -49,14 +44,15 @@ jobs:
           PYTEST_ADDOPTS: "--cov=${{ steps.pkg.outputs.name }} --cov-report=xml --cov-append -q"
 
       - name: Generate all badges
+        shell: uv run python {0}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PDK_MODULE: ${{ steps.pkg.outputs.module }}
         run: |
-          mkdir -p badges
-          uv run python - <<'PYEOF'
           import importlib, os, subprocess, xml.etree.ElementTree as ET
           from pathlib import Path
+
+          os.makedirs("badges", exist_ok=True)
 
           SVG_TEMPLATE = """\
           <svg xmlns="http://www.w3.org/2000/svg" width="{width}" height="20">
@@ -135,7 +131,6 @@ jobs:
           open_prs = gh_count("is:pr+is:open")
           make_badge("issues", str(open_issues), "#4c1" if open_issues == 0 else ("#dfb317" if open_issues < 10 else "#e05d44"), "issues.svg")
           make_badge("PRs", str(open_prs), "#4c1" if open_prs == 0 else ("#dfb317" if open_prs < 10 else "#e05d44"), "prs.svg")
-          PYEOF
 
       - name: Push badges to badges branch
         if: github.ref == 'refs/heads/main'


### PR DESCRIPTION
Refactored GitHub Actions workflows to use the `shell: uv run python {0}` pattern instead of shell command substitutions and heredocs. I think this would be cleaner as everything would be in Python

### Changes
- Updated `test_coverage.yml` to use native Python steps for package detection and summary generation.
- Updated `update_badges.yml` to consolidate Python calls and use the `uv run` shell for badge generation.
- Updated `model_coverage.yml` to use the `uv run` shell.
- Replaced complex shell logic with idiomatic Python, including file operations and environment interaction.