### PR TITLE
Make secrets optional in reusable workflows

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -3,7 +3,7 @@ on:
   workflow_call:
     secrets:
       ANTHROPIC_API_KEY:
-        required: true
+        required: false
   pull_request:
     types: [opened, synchronize, reopened]
 permissions:

--- a/.github/workflows/drc.yml
+++ b/.github/workflows/drc.yml
@@ -3,7 +3,7 @@ on:
   workflow_call:
     secrets:
       GFP_API_KEY:
-        required: true
+        required: false
 env:
   GFP_API_KEY: ${{ secrets.GFP_API_KEY }}
 permissions:

--- a/.github/workflows/model_coverage.yml
+++ b/.github/workflows/model_coverage.yml
@@ -3,7 +3,7 @@ on:
   workflow_call:
     secrets:
       GFP_API_KEY:
-        required: true
+        required: false
 env:
   GFP_API_KEY: ${{ secrets.GFP_API_KEY }}
 concurrency:

--- a/.github/workflows/model_regression.yml
+++ b/.github/workflows/model_regression.yml
@@ -3,7 +3,7 @@ on:
   workflow_call:
     secrets:
       GFP_API_KEY:
-        required: true
+        required: false
 env:
   GFP_API_KEY: ${{ secrets.GFP_API_KEY }}
 concurrency:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -3,9 +3,9 @@ on:
   workflow_call:
     secrets:
       GFP_API_KEY:
-        required: true
+        required: false
       SIMCLOUD_APIKEY:
-        required: true
+        required: false
 jobs:
   build-docs:
     if: github.event_name != 'pull_request' || github.event.pull_request.user.login != 'dependabot[bot]'

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -7,7 +7,7 @@ on:
   workflow_call:
     secrets:
       ANTHROPIC_API_KEY:
-        required: true
+        required: false
 permissions:
   contents: read
 jobs:

--- a/.github/workflows/test_code.yml
+++ b/.github/workflows/test_code.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     secrets:
       GFP_API_KEY:
-        required: true
+        required: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/test_coverage.yml
+++ b/.github/workflows/test_coverage.yml
@@ -3,7 +3,7 @@ on:
   workflow_call:
     secrets:
       GFP_API_KEY:
-        required: true
+        required: false
 env:
   GFP_API_KEY: ${{ secrets.GFP_API_KEY }}
 concurrency:

--- a/.github/workflows/update_badges.yml
+++ b/.github/workflows/update_badges.yml
@@ -3,7 +3,7 @@ on:
   workflow_call:
     secrets:
       GFP_API_KEY:
-        required: true
+        required: false
 env:
   GFP_API_KEY: ${{ secrets.GFP_API_KEY }}
 permissions:


### PR DESCRIPTION
## Summary
- Change `required: true` to `required: false` for `GFP_API_KEY` and `SIMCLOUD_APIKEY` in all reusable workflows
- Fixes CI failures when callers use `secrets: inherit` but don't have the secret configured (e.g. fork PRs, new repos)
- Workflows that need the key still receive it via `secrets: inherit` when available; steps that need it will fail gracefully

## Test plan
- [ ] Verify ph18da CI passes with `secrets: inherit` after this merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)