### PR TITLE
Revert "Make secrets optional in reusable workflows"

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -3,7 +3,7 @@ on:
   workflow_call:
     secrets:
       ANTHROPIC_API_KEY:
-        required: false
+        required: true
   pull_request:
     types: [opened, synchronize, reopened]
 permissions:

--- a/.github/workflows/drc.yml
+++ b/.github/workflows/drc.yml
@@ -3,7 +3,7 @@ on:
   workflow_call:
     secrets:
       GFP_API_KEY:
-        required: false
+        required: true
 env:
   GFP_API_KEY: ${{ secrets.GFP_API_KEY }}
 permissions:

--- a/.github/workflows/model_coverage.yml
+++ b/.github/workflows/model_coverage.yml
@@ -3,7 +3,7 @@ on:
   workflow_call:
     secrets:
       GFP_API_KEY:
-        required: false
+        required: true
 env:
   GFP_API_KEY: ${{ secrets.GFP_API_KEY }}
 concurrency:

--- a/.github/workflows/model_regression.yml
+++ b/.github/workflows/model_regression.yml
@@ -3,7 +3,7 @@ on:
   workflow_call:
     secrets:
       GFP_API_KEY:
-        required: false
+        required: true
 env:
   GFP_API_KEY: ${{ secrets.GFP_API_KEY }}
 concurrency:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -3,9 +3,9 @@ on:
   workflow_call:
     secrets:
       GFP_API_KEY:
-        required: false
+        required: true
       SIMCLOUD_APIKEY:
-        required: false
+        required: true
 jobs:
   build-docs:
     if: github.event_name != 'pull_request' || github.event.pull_request.user.login != 'dependabot[bot]'

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -7,7 +7,7 @@ on:
   workflow_call:
     secrets:
       ANTHROPIC_API_KEY:
-        required: false
+        required: true
 permissions:
   contents: read
 jobs:

--- a/.github/workflows/test_code.yml
+++ b/.github/workflows/test_code.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     secrets:
       GFP_API_KEY:
-        required: false
+        required: true
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/test_coverage.yml
+++ b/.github/workflows/test_coverage.yml
@@ -3,7 +3,7 @@ on:
   workflow_call:
     secrets:
       GFP_API_KEY:
-        required: false
+        required: true
 env:
   GFP_API_KEY: ${{ secrets.GFP_API_KEY }}
 concurrency:

--- a/.github/workflows/update_badges.yml
+++ b/.github/workflows/update_badges.yml
@@ -3,7 +3,7 @@ on:
   workflow_call:
     secrets:
       GFP_API_KEY:
-        required: false
+        required: true
 env:
   GFP_API_KEY: ${{ secrets.GFP_API_KEY }}
 permissions:


### PR DESCRIPTION
Reverts doplaydo/pdk-ci-workflow#111

1. Fix the key distribution problem, these flows require keys - provide them

2. Do not route around the review process for this repository.