### PR TITLE
Use explicit GFP_API_KEY in workflow templates

### DIFF
--- a/templates/.github/workflows/claude-pr-review.yml
+++ b/templates/.github/workflows/claude-pr-review.yml
@@ -8,4 +8,5 @@ on:
 jobs:
   review:
     uses: doplaydo/pdk-ci-workflow/.github/workflows/claude-pr-review.yml@main
-    secrets: inherit
+    secrets:
+      GFP_API_KEY: ${{ secrets.GFP_API_KEY }}

--- a/templates/.github/workflows/drc.yml
+++ b/templates/.github/workflows/drc.yml
@@ -7,4 +7,5 @@ on:
 jobs:
   drc:
     uses: doplaydo/pdk-ci-workflow/.github/workflows/drc.yml@main
-    secrets: inherit
+    secrets:
+      GFP_API_KEY: ${{ secrets.GFP_API_KEY }}

--- a/templates/.github/workflows/model_coverage.yml
+++ b/templates/.github/workflows/model_coverage.yml
@@ -8,4 +8,5 @@ on:
 jobs:
   model-coverage:
     uses: doplaydo/pdk-ci-workflow/.github/workflows/model_coverage.yml@main
-    secrets: inherit
+    secrets:
+      GFP_API_KEY: ${{ secrets.GFP_API_KEY }}

--- a/templates/.github/workflows/model_regression.yml
+++ b/templates/.github/workflows/model_regression.yml
@@ -8,4 +8,5 @@ on:
 jobs:
   model-regression:
     uses: doplaydo/pdk-ci-workflow/.github/workflows/model_regression.yml@main
-    secrets: inherit
+    secrets:
+      GFP_API_KEY: ${{ secrets.GFP_API_KEY }}

--- a/templates/.github/workflows/pages.yml
+++ b/templates/.github/workflows/pages.yml
@@ -8,4 +8,5 @@ on:
 jobs:
   docs:
     uses: doplaydo/pdk-ci-workflow/.github/workflows/pages.yml@main
-    secrets: inherit
+    secrets:
+      GFP_API_KEY: ${{ secrets.GFP_API_KEY }}

--- a/templates/.github/workflows/release-drafter.yml
+++ b/templates/.github/workflows/release-drafter.yml
@@ -7,4 +7,5 @@ on:
 jobs:
   draft:
     uses: doplaydo/pdk-ci-workflow/.github/workflows/release-drafter.yml@main
-    secrets: inherit
+    secrets:
+      GFP_API_KEY: ${{ secrets.GFP_API_KEY }}

--- a/templates/.github/workflows/test_code.yml
+++ b/templates/.github/workflows/test_code.yml
@@ -7,4 +7,5 @@ on:
 jobs:
   test:
     uses: doplaydo/pdk-ci-workflow/.github/workflows/test_code.yml@main
-    secrets: inherit
+    secrets:
+      GFP_API_KEY: ${{ secrets.GFP_API_KEY }}

--- a/templates/.github/workflows/test_coverage.yml
+++ b/templates/.github/workflows/test_coverage.yml
@@ -8,4 +8,5 @@ on:
 jobs:
   coverage:
     uses: doplaydo/pdk-ci-workflow/.github/workflows/test_coverage.yml@main
-    secrets: inherit
+    secrets:
+      GFP_API_KEY: ${{ secrets.GFP_API_KEY }}

--- a/templates/.github/workflows/update_badges.yml
+++ b/templates/.github/workflows/update_badges.yml
@@ -9,4 +9,5 @@ on:
 jobs:
   badges:
     uses: doplaydo/pdk-ci-workflow/.github/workflows/update_badges.yml@main
-    secrets: inherit
+    secrets:
+      GFP_API_KEY: ${{ secrets.GFP_API_KEY }}


### PR DESCRIPTION
## Summary
- Replace `secrets: inherit` with explicit `secrets: GFP_API_KEY` in all 9 workflow templates
- `secrets: inherit` doesn't reliably pass secrets in PR contexts, causing `Invalid GFP_API_KEY` errors
- This aligns templates with what downstream repos (e.g. ph18da) need for `check-template-drift` to pass

## Test plan
- [ ] Merge this, then verify ph18da CI passes with matching workflow files

🤖 Generated with [Claude Code](https://claude.com/claude-code)