### PR TITLE
Pin pre-commit rev to SHA instead of main

### DIFF
--- a/templates/.pre-commit-config.yaml
+++ b/templates/.pre-commit-config.yaml
@@ -12,7 +12,7 @@
 
 repos:
   - repo: https://github.com/doplaydo/pdk-ci-workflow
-    rev: main
+    rev: 4c8efcfae3b16f3ab11cb3a18f0d241528e824c6
     hooks:
       # PDK structure validation
       - id: check-required-files


### PR DESCRIPTION
## Summary
- Pin `rev:` in the canonical `.pre-commit-config.yaml` template to a specific SHA instead of `main`
- `rev: main` is a mutable reference that pre-commit caches on first install and never updates, causing CI to use stale hook code even after upstream changes
- This ensures CI cache busts when templates/hooks are updated

## Test plan
- [ ] Merge and verify ph18da CI pre-commit picks up latest templates

🤖 Generated with [Claude Code](https://claude.com/claude-code)