### PR TITLE
Make secrets optional in reusable workflows

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -3,7 +3,7 @@ on:
   workflow_call:
     secrets:
       ANTHROPIC_API_KEY:
-        required: true
+        required: false
   pull_request:
     types: [opened, synchronize, reopened]
 permissions:

--- a/.github/workflows/drc.yml
+++ b/.github/workflows/drc.yml
@@ -3,7 +3,7 @@ on:
   workflow_call:
     secrets:
       GFP_API_KEY:
-        required: true
+        required: false
 env:
   GFP_API_KEY: ${{ secrets.GFP_API_KEY }}
 permissions:

--- a/.github/workflows/model_coverage.yml
+++ b/.github/workflows/model_coverage.yml
@@ -3,7 +3,7 @@ on:
   workflow_call:
     secrets:
       GFP_API_KEY:
-        required: true
+        required: false
 env:
   GFP_API_KEY: ${{ secrets.GFP_API_KEY }}
 concurrency:

--- a/.github/workflows/model_regression.yml
+++ b/.github/workflows/model_regression.yml
@@ -3,7 +3,7 @@ on:
   workflow_call:
     secrets:
       GFP_API_KEY:
-        required: true
+        required: false
 env:
   GFP_API_KEY: ${{ secrets.GFP_API_KEY }}
 concurrency:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -3,9 +3,9 @@ on:
   workflow_call:
     secrets:
       GFP_API_KEY:
-        required: true
+        required: false
       SIMCLOUD_APIKEY:
-        required: true
+        required: false
 jobs:
   build-docs:
     if: github.event_name != 'pull_request' || github.event.pull_request.user.login != 'dependabot[bot]'

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -7,7 +7,7 @@ on:
   workflow_call:
     secrets:
       ANTHROPIC_API_KEY:
-        required: true
+        required: false
 permissions:
   contents: read
 jobs:

--- a/.github/workflows/test_code.yml
+++ b/.github/workflows/test_code.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     secrets:
       GFP_API_KEY:
-        required: true
+        required: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/test_coverage.yml
+++ b/.github/workflows/test_coverage.yml
@@ -3,7 +3,7 @@ on:
   workflow_call:
     secrets:
       GFP_API_KEY:
-        required: true
+        required: false
 env:
   GFP_API_KEY: ${{ secrets.GFP_API_KEY }}
 concurrency:

--- a/.github/workflows/update_badges.yml
+++ b/.github/workflows/update_badges.yml
@@ -3,7 +3,7 @@ on:
   workflow_call:
     secrets:
       GFP_API_KEY:
-        required: true
+        required: false
 env:
   GFP_API_KEY: ${{ secrets.GFP_API_KEY }}
 permissions:


### PR DESCRIPTION
## Summary
- Change `required: true` to `required: false` for all secrets in all 9 reusable workflows
- Templates use `secrets: inherit`, which doesn't satisfy `required: true` validation at workflow parse time
- This mismatch causes all downstream PDK repos (e.g. ph18da) to fail CI with: `Secret GFP_API_KEY is required, but not provided while calling`

## Context
- PR #113 (explicit secrets in templates) was reverted, confirming the preferred approach is `secrets: inherit` in templates
- PR #111 (same fix as this) was merged then reverted — but the underlying issue remains: downstream CI is broken
- The secrets still get passed via `secrets: inherit` at runtime; removing `required` only skips the parse-time check

## Test plan
- [ ] Merge this PR
- [ ] Re-run CI on olp-dpd/ph18da#87 and verify all checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)