### PR TITLE
fix: move deploy-docs into caller template to resolve startup_failure

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -6,6 +6,10 @@ on:
         required: false
       SIMCLOUD_APIKEY:
         required: false
+permissions:
+  pages: write
+  id-token: write
+  contents: read
 jobs:
   build-docs:
     if: github.event_name != 'pull_request' || github.event.pull_request.user.login != 'dependabot[bot]'
@@ -35,9 +39,6 @@ jobs:
   deploy-docs:
     needs: build-docs
     if: ${{ github.ref == 'refs/heads/main' }}
-    permissions:
-      pages: write
-      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -6,10 +6,6 @@ on:
         required: false
       SIMCLOUD_APIKEY:
         required: false
-permissions:
-  pages: write
-  id-token: write
-  contents: read
 jobs:
   build-docs:
     if: github.event_name != 'pull_request' || github.event.pull_request.user.login != 'dependabot[bot]'
@@ -36,15 +32,3 @@ jobs:
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5
         with:
           path: "./docs/_build/html/"
-  deploy-docs:
-    needs: build-docs
-    if: ${{ github.ref == 'refs/heads/main' }}
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
-        

--- a/templates/.github/dependabot.yml
+++ b/templates/.github/dependabot.yml
@@ -18,3 +18,7 @@ updates:
       interval: monthly
     ignore:
       - dependency-name: "doplaydo/*"
+      # actions/deploy-pages is pinned in templates/.github/workflows/pages.yml
+      # and kept in sync by check_template_drift.py. Bumping it here causes drift
+      # churn — upgrades are owned by the pdk-ci-workflow repo.
+      - dependency-name: "actions/deploy-pages"

--- a/templates/.github/workflows/pages.yml
+++ b/templates/.github/workflows/pages.yml
@@ -9,3 +9,17 @@ jobs:
   docs:
     uses: doplaydo/pdk-ci-workflow/.github/workflows/pages.yml@main
     secrets: inherit
+  deploy-docs:
+    needs: docs
+    if: ${{ github.ref == 'refs/heads/main' }}
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0


### PR DESCRIPTION
## Summary
- Removes `deploy-docs` job from the reusable workflow (`.github/workflows/pages.yml`)
- Adds `deploy-docs` to the caller template (`templates/.github/workflows/pages.yml`)
- Build-docs stays centralized in the reusable workflow
- `check_template_drift.py` will auto-propagate the new template to all PDK repos on next pre-commit run

## Root Cause
GitHub Actions cannot validate `environment` + job-level `permissions` through `workflow_call` boundaries. This causes `startup_failure` (zero jobs, no logs) on every caller. Investigation confirmed that **every successful pages.yml run used an inlined workflow** (`referenced_workflows: []`), and **every startup_failure used the reusable workflow** (`referenced_workflows: 1`). The reusable `deploy-docs` job has never worked.

The break correlates with the `deploy-pages` v4→v5 bump (Apr 1), but the root issue is the `workflow_call` + `permissions` + `environment` combination that GitHub cannot resolve at startup time.

## Test plan
- [ ] Merge and update a PDK repo's `pages.yml` via pre-commit template drift
- [ ] Trigger `pages.yml` on `gdsfactory/gf180mcu` — should no longer get `startup_failure`
- [ ] Verify docs build and deploy to GitHub Pages on push to `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)