### PR TITLE
Fix reusable workflows concurrency collisions by hardcoding names

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -6,6 +6,9 @@ on:
         required: false
   pull_request:
     types: [opened, synchronize, reopened]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}-claude-pr-review
+  cancel-in-progress: true
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/drc.yml
+++ b/.github/workflows/drc.yml
@@ -10,7 +10,7 @@ permissions:
   contents: write
   pull-requests: write
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-drc
   cancel-in-progress: true
 jobs:
   drc:

--- a/.github/workflows/model_coverage.yml
+++ b/.github/workflows/model_coverage.yml
@@ -7,7 +7,7 @@ on:
 env:
   GFP_API_KEY: ${{ secrets.GFP_API_KEY }}
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-model_coverage
   cancel-in-progress: true
 jobs:
   model-coverage:

--- a/.github/workflows/model_regression.yml
+++ b/.github/workflows/model_regression.yml
@@ -7,7 +7,7 @@ on:
 env:
   GFP_API_KEY: ${{ secrets.GFP_API_KEY }}
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-model_regression
   cancel-in-progress: true
 jobs:
   model-regression:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -6,6 +6,9 @@ on:
         required: false
       SIMCLOUD_APIKEY:
         required: false
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-pages
+  cancel-in-progress: false
 jobs:
   build-docs:
     if: github.event_name != 'pull_request' || github.event.pull_request.user.login != 'dependabot[bot]'

--- a/.github/workflows/test_code.yml
+++ b/.github/workflows/test_code.yml
@@ -7,7 +7,7 @@ on:
         required: false
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-test_code
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/test_coverage.yml
+++ b/.github/workflows/test_coverage.yml
@@ -7,7 +7,7 @@ on:
 env:
   GFP_API_KEY: ${{ secrets.GFP_API_KEY }}
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-test_coverage
   cancel-in-progress: true
 jobs:
   coverage:

--- a/.github/workflows/update_badges.yml
+++ b/.github/workflows/update_badges.yml
@@ -11,7 +11,7 @@ permissions:
   issues: read
   pull-requests: read
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-update_badges
   cancel-in-progress: true
 jobs:
   badges:


### PR DESCRIPTION
This PR fixes unintended job cancellations by hardcoding the reusable workflow names into their respective `concurrency` group IDs. Before, the concurrency groups would clash if the reusable workflows were called as individual jobs from a single workflow.

### Applied Configuration (Example for test_code.yml):
```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}-test_code
  cancel-in-progress: true
```