### PR TITLE
fix: pin pre-commit rev to upstream SHA to bust stale action cache

### DIFF
--- a/.github/workflows/test_code.yml
+++ b/.github/workflows/test_code.yml
@@ -21,8 +21,14 @@ jobs:
     - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
     - name: Fetch canonical pre-commit config
       run: |
-        curl -fSL https://raw.githubusercontent.com/doplaydo/pdk-ci-workflow/main/templates/.pre-commit-config.yaml \
+        # Resolve upstream main to a real SHA and bake it into the config so
+        # pre-commit/action's cache key (hashFiles of the config) invalidates
+        # whenever upstream moves. With a literal `rev: main`, the hash is
+        # stable and stale hook envs stick around indefinitely.
+        SHA=$(git ls-remote https://github.com/doplaydo/pdk-ci-workflow.git main | cut -f1)
+        curl -fSL "https://raw.githubusercontent.com/doplaydo/pdk-ci-workflow/${SHA}/templates/.pre-commit-config.yaml" \
           -o .pre-commit-config.yaml
+        sed -i "s|rev: main|rev: ${SHA}|" .pre-commit-config.yaml
     - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
   test_code:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- `test_code.yml` fetches `.pre-commit-config.yaml` from upstream `main` with `rev: main` baked in
- `pre-commit/action@v3.0.1` keys its hook-env cache on `hashFiles('.pre-commit-config.yaml')`, so with a floating `rev: main` the hash never changes
- Result: every downstream PDK repo hits a cached install of `ci-pdk-workflows` built against an old `main`. `check-template-drift` then reads **stale** templates out of that cached venv and **reverts** legitimate template syncs
- Seen in the wild: [gdsfactory/IHP#147](https://github.com/gdsfactory/IHP/pull/147) — the drift hook stripped the `deploy-docs` job (added in #117) and the `actions/deploy-pages` dependabot ignore back out of the PR

## Fix
Resolve `main` to a real SHA at fetch time and `sed` it into the config before `pre-commit/action` runs. The cache key now includes the upstream SHA and invalidates cleanly whenever the reusable workflow's templates change.

## Test plan
- [ ] Merge
- [ ] Re-run CI on gdsfactory/IHP#147 — `test / pre-commit` should pass without rewriting files
- [ ] Spot-check one other PDK repo run to confirm cache invalidates on the next upstream bump