### PR TITLE
Use explicit secrets in workflow templates

### DIFF
--- a/templates/.github/workflows/claude-pr-review.yml
+++ b/templates/.github/workflows/claude-pr-review.yml
@@ -8,4 +8,5 @@ on:
 jobs:
   review:
     uses: doplaydo/pdk-ci-workflow/.github/workflows/claude-pr-review.yml@main
-    secrets: inherit
+    secrets:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/templates/.github/workflows/drc.yml
+++ b/templates/.github/workflows/drc.yml
@@ -7,4 +7,5 @@ on:
 jobs:
   drc:
     uses: doplaydo/pdk-ci-workflow/.github/workflows/drc.yml@main
-    secrets: inherit
+    secrets:
+      GFP_API_KEY: ${{ secrets.GFP_API_KEY }}

--- a/templates/.github/workflows/model_coverage.yml
+++ b/templates/.github/workflows/model_coverage.yml
@@ -8,4 +8,5 @@ on:
 jobs:
   model-coverage:
     uses: doplaydo/pdk-ci-workflow/.github/workflows/model_coverage.yml@main
-    secrets: inherit
+    secrets:
+      GFP_API_KEY: ${{ secrets.GFP_API_KEY }}

--- a/templates/.github/workflows/model_regression.yml
+++ b/templates/.github/workflows/model_regression.yml
@@ -8,4 +8,5 @@ on:
 jobs:
   model-regression:
     uses: doplaydo/pdk-ci-workflow/.github/workflows/model_regression.yml@main
-    secrets: inherit
+    secrets:
+      GFP_API_KEY: ${{ secrets.GFP_API_KEY }}

--- a/templates/.github/workflows/pages.yml
+++ b/templates/.github/workflows/pages.yml
@@ -8,7 +8,9 @@ on:
 jobs:
   docs:
     uses: doplaydo/pdk-ci-workflow/.github/workflows/pages.yml@main
-    secrets: inherit
+    secrets:
+      GFP_API_KEY: ${{ secrets.GFP_API_KEY }}
+      SIMCLOUD_APIKEY: ${{ secrets.SIMCLOUD_APIKEY }}
   deploy-docs:
     needs: docs
     if: ${{ github.ref == 'refs/heads/main' }}

--- a/templates/.github/workflows/release-drafter.yml
+++ b/templates/.github/workflows/release-drafter.yml
@@ -7,4 +7,5 @@ on:
 jobs:
   draft:
     uses: doplaydo/pdk-ci-workflow/.github/workflows/release-drafter.yml@main
-    secrets: inherit
+    secrets:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/templates/.github/workflows/test_code.yml
+++ b/templates/.github/workflows/test_code.yml
@@ -7,4 +7,5 @@ on:
 jobs:
   test:
     uses: doplaydo/pdk-ci-workflow/.github/workflows/test_code.yml@main
-    secrets: inherit
+    secrets:
+      GFP_API_KEY: ${{ secrets.GFP_API_KEY }}

--- a/templates/.github/workflows/test_coverage.yml
+++ b/templates/.github/workflows/test_coverage.yml
@@ -8,4 +8,5 @@ on:
 jobs:
   coverage:
     uses: doplaydo/pdk-ci-workflow/.github/workflows/test_coverage.yml@main
-    secrets: inherit
+    secrets:
+      GFP_API_KEY: ${{ secrets.GFP_API_KEY }}

--- a/templates/.github/workflows/update_badges.yml
+++ b/templates/.github/workflows/update_badges.yml
@@ -9,4 +9,5 @@ on:
 jobs:
   badges:
     uses: doplaydo/pdk-ci-workflow/.github/workflows/update_badges.yml@main
-    secrets: inherit
+    secrets:
+      GFP_API_KEY: ${{ secrets.GFP_API_KEY }}


### PR DESCRIPTION
## Summary
- Replace `secrets: inherit` with explicit secret mapping in all 9 workflow templates
- `secrets: inherit` does not reliably pass secrets to cross-repo reusable workflows
- Downstream repos (e.g. ph18da) fail with `LicenseError: Invalid GFP_API_KEY` because the secret value isn't forwarded

## Evidence
- ph18da main branch uses explicit `secrets: GFP_API_KEY: ${{ secrets.GFP_API_KEY }}` → tests **pass**
- ph18da PR branch uses `secrets: inherit` (synced from template) → tests **fail** with `Invalid GFP_API_KEY`
- PR #113 applied this same fix but was reverted; PR #116 made secrets optional instead, which allows workflows to start but doesn't solve the underlying issue of secrets not being forwarded

## Changes
| Template | Secret(s) |
|----------|-----------|
| test_code, test_coverage, model_coverage, model_regression, drc, update_badges | `GFP_API_KEY` |
| pages | `GFP_API_KEY`, `SIMCLOUD_APIKEY` |
| claude-pr-review, release-drafter | `ANTHROPIC_API_KEY` |

## Test plan
- [ ] Merge this PR
- [ ] Clean pre-commit cache in ph18da (`pre-commit clean`)
- [ ] Re-run ph18da CI and verify all checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)