### PR TITLE
Reduce artifact retention from 14 to 3 days

### DIFF
--- a/.github/workflows/drc.yml
+++ b/.github/workflows/drc.yml
@@ -39,6 +39,7 @@ jobs:
           path: |
             build/lyrdb/
             build/gds/all_cells.gds
+          retention-days: 3
       - name: Create and commit DRC badge
         if: always()
         run: |

--- a/.github/workflows/model_regression.yml
+++ b/.github/workflows/model_regression.yml
@@ -39,4 +39,4 @@ jobs:
           name: difftest-report-model_regression
           path: test_diffs/
           if-no-files-found: ignore
-          retention-days: 14
+          retention-days: 3

--- a/.github/workflows/test_code.yml
+++ b/.github/workflows/test_code.yml
@@ -46,7 +46,7 @@ jobs:
           name: difftest-report-test_code
           path: test_diffs/
           if-no-files-found: ignore
-          retention-days: 14
+          retention-days: 3
   test_gfp:
     runs-on: ubuntu-latest
     steps:
@@ -69,4 +69,4 @@ jobs:
           name: difftest-report-test_gfp
           path: test_diffs/
           if-no-files-found: ignore
-          retention-days: 14
+          retention-days: 3


### PR DESCRIPTION
## Summary
- Reduce `retention-days` from 14 to 3 in test_code, model_regression, and drc workflows
- Add missing `retention-days` to drc-report artifact upload
- Downstream repos (e.g. ph18da) are hitting GitHub Actions storage quotas

## Test plan
- [ ] Verify artifacts still upload on failure
- [ ] Monitor storage usage after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)