### PR TITLE
Add integration test workflows for cspdk and hhi

### DIFF
--- a/.github/workflows/test_cspdk.yml
+++ b/.github/workflows/test_cspdk.yml
@@ -1,0 +1,31 @@
+name: Test cspdk
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-test_cspdk
+  cancel-in-progress: true
+
+jobs:
+  test_cspdk:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout cspdk
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          repository: gdsfactory/cspdk
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: '3.12'
+      - name: Install uv
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
+      - name: Install dependencies
+        run: make install
+      - name: Test with pytest
+        run: make test

--- a/.github/workflows/test_hhi.yml
+++ b/.github/workflows/test_hhi.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           repository: doplaydo/hhi
-          token: ${{ secrets.GH_PAT }}
+          token: ${{ secrets.PDK_PAT }}
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:

--- a/.github/workflows/test_hhi.yml
+++ b/.github/workflows/test_hhi.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           repository: doplaydo/hhi
-          token: ${{ secrets.PDK_PAT }}
+          token: ${{ secrets.PDK_PAT || github.token }}
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:

--- a/.github/workflows/test_hhi.yml
+++ b/.github/workflows/test_hhi.yml
@@ -1,0 +1,31 @@
+name: Test hhi
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-test_hhi
+  cancel-in-progress: true
+
+jobs:
+  test_hhi:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout hhi
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          repository: doplaydo/hhi
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: '3.12'
+      - name: Install uv
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
+      - name: Install dependencies
+        run: make install
+      - name: Test with pytest
+        run: make test

--- a/.github/workflows/test_hhi.yml
+++ b/.github/workflows/test_hhi.yml
@@ -19,6 +19,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           repository: doplaydo/hhi
+          token: ${{ secrets.GH_PAT }}
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:


### PR DESCRIPTION
## Summary
- Add `test_cspdk.yml` workflow that checks out `gdsfactory/cspdk` and runs its test suite
- Add `test_hhi.yml` workflow that checks out `doplaydo/hhi` and runs its test suite
- Both trigger on push to main, PRs, and manual dispatch to validate CI changes against real PDK repos

## Test plan
- [ ] Verify `test_cspdk` workflow runs successfully against gdsfactory/cspdk
- [ ] Verify `test_hhi` workflow runs successfully against doplaydo/hhi

🤖 Generated with [Claude Code](https://claude.com/claude-code)