### PR TITLE
Fix check-template-drift vs ruff-lint race on build_cell.py

### DIFF
--- a/templates/build_cell.py
+++ b/templates/build_cell.py
@@ -44,7 +44,7 @@ if cell_name == "all_cells":
 
         try:
             c.add_ref(func())
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001
             print(f"Error instantiating cell {name}: {e}")
     c.write_gds(f"build/gds/{cell_name}.gds")
 else:


### PR DESCRIPTION
## Summary
- `check-template-drift` rewrites downstream `build_cell.py` to match this template, then `ruff-lint` rejects it with `BLE001` (broad `Exception` catch). This makes `pre-commit run --all-files` fail deterministically on every downstream PDK repo.
- Adds `# noqa: BLE001` to the intentional broad catch — cell instantiation failures should log and continue, not abort the build.

## Repro
Any downstream PDK repo on a clean checkout: `uv run pre-commit run --all-files`
Example: https://github.com/doplaydo/tps45/actions

## Test plan
- [ ] Run `pre-commit run --all-files` on a downstream PDK repo after this merges


closes https://github.com/doplaydo/pdk-ci-workflow/issues/127