### PR TITLE
Fix stale pre-commit cache in CI with mutable rev: main

### DIFF
--- a/.github/workflows/test_code.yml
+++ b/.github/workflows/test_code.yml
@@ -23,7 +23,10 @@ jobs:
       run: |
         curl -fSL https://raw.githubusercontent.com/doplaydo/pdk-ci-workflow/main/templates/.pre-commit-config.yaml \
           -o .pre-commit-config.yaml
-    - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
+    - name: Run pre-commit (no cache — rev uses mutable main branch)
+      run: |
+        pip install pre-commit
+        pre-commit run --all-files
   test_code:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary
- `pre-commit/action` caches `~/.cache/pre-commit` across CI runs. Since `.pre-commit-config.yaml` uses `rev: main` (mutable branch ref), the cached hook versions go stale — CI may run different hooks than a fresh checkout.
- This caused local vs CI result mismatches (e.g. the BLE001 race in #128).
- Replaces `pre-commit/action` with a direct `pip install pre-commit && pre-commit run --all-files` so every CI run fetches the latest hooks from main without caching.

## Test plan
- [ ] Verify pre-commit job passes on a downstream PDK repo PR after this merges
- [ ] Confirm CI and local `pre-commit run --all-files` produce the same results