### PR TITLE
Downstream CI via App + repository_dispatch (#47)

### DIFF
--- a/.github/workflows/downstream-dispatch.yml
+++ b/.github/workflows/downstream-dispatch.yml
@@ -1,0 +1,56 @@
+name: Downstream dispatch
+
+# Phase 1: prove App auth + repository_dispatch roundtrip.
+# Manual + push trigger until verified. PR trigger added later.
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "pdk-ci-workflow ref to test (defaults to this workflow's sha)"
+        required: false
+        default: ""
+  # Temporary: fires on every push to this branch so we can iterate before
+  # merging workflow_dispatch support to main. Remove once merged.
+  push:
+    branches:
+      - 47-add-downstream-ci-workflow-via-app-dispatch
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - owner: doplaydo
+            repo: hhi
+          - owner: gdsfactory
+            repo: cspdk
+    steps:
+      - name: Generate App token
+        id: app-token
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
+        with:
+          app-id: ${{ vars.GH_APP_PDK_WORKFLOW_APP_ID }}
+          private-key: ${{ secrets.GH_APP_PDK_WORKFLOW_PRIVATE_KEY }}
+          owner: ${{ matrix.owner }}
+          repositories: ${{ matrix.repo }}
+
+      - name: Send repository_dispatch
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          OWNER: ${{ matrix.owner }}
+          REPO: ${{ matrix.repo }}
+          REF: ${{ github.event.inputs.ref || github.sha }}
+          PR_NUMBER: "0"
+          SOURCE_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          echo "Dispatching pdk-ci-workflow-test to $OWNER/$REPO (ref=$REF)"
+          gh api --method POST "repos/$OWNER/$REPO/dispatches" \
+            -f "event_type=pdk-ci-workflow-test" \
+            -f "client_payload[ref]=$REF" \
+            -f "client_payload[pr_number]=$PR_NUMBER" \
+            -f "client_payload[source_repo]=$SOURCE_REPO"
+          echo "Dispatched. Check https://github.com/$OWNER/$REPO/actions for event."


### PR DESCRIPTION
## Summary

Phase 1 of #47. Adds a dispatcher workflow that uses the `pdk-ci-workflow` GitHub App to send `repository_dispatch` events to downstream PDK repos, so the PDKs can run reusable workflows at the upstream PR's ref and report results back.

Approach chosen over alternatives:
- PR #51 (ref-rewrite via classic PAT) — rejected, PAT sprawl + security concerns raised by @ThomasPluck
- PR #123 (static PDK test runs) — rejected, doesn't exercise upstream PR branch at all (PDKs pin `@main`)
- This PR (App + `repository_dispatch`) — per @diofeher's suggestion

## What's here

- `.github/workflows/downstream-dispatch.yml` — mints App token, fans out `repository_dispatch` to `hhi` and `cspdk`. Manual + push trigger only for now (no `pull_request` until auth + receiver proven).

## Known blockers

- [ ] Org var `GH_APP_PDK_WORKFLOW_APP_ID` + secret `GH_APP_PDK_WORKFLOW_PRIVATE_KEY` currently scoped to "Private and internal repositories" only. `pdk-ci-workflow` is public → evaluates empty → auth fails. @diofeher to widen to include this repo.
- [ ] App install coverage across `hhi` and `gdsfactory/cspdk` to be confirmed.

## Remaining phases

1. ~~Dispatcher skeleton~~ (this PR)
2. Verify auth roundtrip (blocked on above)
3. Debug receiver on one PDK (echoes payload)
4. Real receiver calling `uses: doplaydo/pdk-ci-workflow/.github/workflows/*.yml@<dispatched ref>`
5. Status reporter posting check-runs back to upstream PR
6. Flip trigger from `push`/manual to `pull_request`
7. Fan-out polish (auto-discovery of additional PDKs, concurrency, timeouts)

## Test plan

- [ ] Phase 2: auth roundtrip — dispatcher green, target PDK Actions tab shows `repository_dispatch` event
- [ ] Phase 3: debug receiver prints `client_payload.ref` matching upstream PR sha
- [ ] Phase 4: breaking change to `test_code.yml` in a draft upstream PR causes receiver to fail
- [ ] Phase 5: check-run appears on upstream PR with deep-link to PDK-side run log

Closes #47 (when complete).

🤖 Generated with [Claude Code](https://claude.com/claude-code)