### PR TITLE
contain claude reviewer bot: opt-in re-runs, dedup, scope, severity

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -10,7 +10,7 @@ PDK repos create thin wrapper workflows that call these using `secrets: inherit`
 |----------|------|-------------|-------------|
 | `test_code.yml` | pre-commit, test_code, test_gfp | `GFP_API_KEY` | Pre-commit (fetches canonical config), pytest, GFP validation |
 | `pages.yml` | build-docs, deploy-docs | `GFP_API_KEY`, `SIMCLOUD_APIKEY` | Sphinx docs build and GitHub Pages deployment |
-| `claude-pr-review.yml` | review | `ANTHROPIC_API_KEY` | AI code review via Claude Sonnet 4 on PRs |
+| `claude-pr-review.yml` | review | `ANTHROPIC_API_KEY` | AI code review via Claude Sonnet 4. Auto-runs on PR open/reopen; re-runs only when a human posts `/claude-api review` on the PR |
 | `release-drafter.yml` | update_release_draft | `GITHUB_TOKEN`, `ANTHROPIC_API_KEY` | Auto-drafted release notes with Claude-curated changelog |
 | `drc.yml` | drc | `GFP_API_KEY` | Design Rule Check with badge generation |
 | `issue.yml` | add-label | `GITHUB_TOKEN` | Auto-labels issues with "pdk" tag |

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -46,18 +46,36 @@ jobs:
           gh api --method POST -H "Accept: application/vnd.github+json" \
             "/repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions" \
             -f content='eyes' || true
-      - name: Dump prior bot review comments
+      - name: Dump PR discussion for dedup
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN || github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+          REPO: ${{ github.repository }}
         run: |
-          {
-            gh api --paginate "/repos/${{ github.repository }}/pulls/$PR_NUMBER/comments" \
-              --jq '.[] | select(.user.type=="Bot") | {kind:"inline", path, line, body}'
-            gh api --paginate "/repos/${{ github.repository }}/issues/$PR_NUMBER/comments" \
-              --jq '.[] | select(.user.type=="Bot") | {kind:"toplevel", body}'
-          } > .claude_prior_comments.jsonl || true
-          echo "prior comments: $(wc -l < .claude_prior_comments.jsonl || echo 0)"
+          owner="${REPO%%/*}"
+          name="${REPO##*/}"
+          gh api graphql -F owner="$owner" -F repo="$name" -F pr="$PR_NUMBER" -f query='
+            query($owner:String!, $repo:String!, $pr:Int!) {
+              repository(owner:$owner, name:$repo) {
+                pullRequest(number:$pr) {
+                  reviewThreads(first:100) {
+                    nodes {
+                      isResolved
+                      isOutdated
+                      path
+                      line
+                      comments(first:50) { nodes { author { login } body } }
+                    }
+                  }
+                }
+              }
+            }' --jq '.data.repository.pullRequest.reviewThreads.nodes[]' \
+            > .claude_pr_threads.jsonl || true
+          gh api --paginate "/repos/$REPO/issues/$PR_NUMBER/comments" \
+            --jq '.[] | {author:.user.login, body}' \
+            > .claude_pr_toplevel.jsonl || true
+          echo "threads: $(wc -l < .claude_pr_threads.jsonl || echo 0)"
+          echo "toplevel: $(wc -l < .claude_pr_toplevel.jsonl || echo 0)"
       - uses: anthropics/claude-code-action@905d4eb99ab3d43143d74fb0dcae537f29ac330a # v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -78,7 +96,7 @@ jobs:
             - Get familiar with the codebase by reading ./AGENTS.md in the repo root.
             - You are called on new commits to the PR, so focus on the latest changes and how they integrate with the existing code. Avoid redundant comments on unchanged code.
             - Cap at 5 comments per review. Pick the most important. Skip anything already caught by ruff/pre-commit.
-            - Before posting, read `.claude_prior_comments.jsonl` (one JSON object per line) — comments you already posted on this PR. Do not repost the same issue (same path and same root cause). If the code referenced by a prior comment no longer exists or is already fixed, skip instead of re-raising.
+            - Before posting, read `.claude_pr_threads.jsonl` (inline review threads, one per line: isResolved, isOutdated, path, line, comments[]) and `.claude_pr_toplevel.jsonl` (top-level PR comments). Skip an issue if any of these are true for a matching prior thread (same path + same root cause): `isResolved: true` (human closed it), `isOutdated: true` (code moved — raise fresh only if still wrong), a human has replied (they've engaged; leave it alone), or the referenced code no longer exists or is already fixed.
 
             Output format — ultra-terse, one line per issue:
             - Drop articles (a/an/the), filler words, pleasantries, and preamble.

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -65,6 +65,7 @@ jobs:
             - Do not write positive feedback or general comments. Only provide constructive criticism and actionable feedback. If there are no issues, no need to comment.
             - Get familiar with the codebase by reading ./AGENTS.md in the repo root.
             - You are called on new commits to the PR, so focus on the latest changes and how they integrate with the existing code. Avoid redundant comments on unchanged code.
+            - Cap at 5 comments per review. Pick the most important. Skip anything already caught by ruff/pre-commit.
 
             Output format — ultra-terse, one line per issue:
             - Drop articles (a/an/the), filler words, pleasantries, and preamble.

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -96,11 +96,12 @@ jobs:
             - Get familiar with the codebase by reading ./AGENTS.md in the repo root.
             - You are called on new commits to the PR, so focus on the latest changes and how they integrate with the existing code. Avoid redundant comments on unchanged code.
             - Cap at 5 comments per review. Pick the most important. Skip anything already caught by ruff/pre-commit.
+            - Only comment on files shown by `gh pr diff --name-only`. Skip files unrelated to this PR.
             - Before posting, read `.claude_pr_threads.jsonl` (inline review threads, one per line: isResolved, isOutdated, path, line, comments[]) and `.claude_pr_toplevel.jsonl` (top-level PR comments). Skip an issue if any of these are true for a matching prior thread (same path + same root cause): `isResolved: true` (human closed it), `isOutdated: true` (code moved — raise fresh only if still wrong), a human has replied (they've engaged; leave it alone), or the referenced code no longer exists or is already fixed.
 
             Output format — ultra-terse, one line per issue:
             - Drop articles (a/an/the), filler words, pleasantries, and preamble.
-            - Prefix each issue with a severity marker: 🔴 bug that should be fixed before merging · 🟡 minor issue, worth fixing but not blocking · 🟣 bug in codebase not introduced by this PR.
+            - Prefix each issue with a severity marker: 🔴 merge-blocker — CI breaks, wrong output/behavior, or security issue · 🟡 worth fixing, not blocking · 🟣 bug in codebase not introduced by this PR. If unsure between 🔴 and 🟡, use 🟡. Cap: at most one 🔴 per review.
             - Each issue: `🔴/🟡/🟣 [file:line] problem. fix.`
             - No summaries. No "Overall, ...". No positive remarks.
 

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -96,6 +96,7 @@ jobs:
             - Get familiar with the codebase by reading ./AGENTS.md in the repo root.
             - You are called on new commits to the PR, so focus on the latest changes and how they integrate with the existing code. Avoid redundant comments on unchanged code.
             - Cap at 5 comments per review. Pick the most important. Skip anything already caught by ruff/pre-commit.
+            - Search for related open issues and PRs: run `gh issue list --repo $REPO --search "<keywords from PR title>" --json number,title,url,state` and `gh pr list --repo $REPO --search "<keywords from PR title>" --json number,title,url,state`. If any results are found that are not already referenced in the PR body or comments via "Closes/Fixes/Related to/References #N", flag with a top-level `gh pr comment`: 🔴 [unlinked: #N — title. Link or close it.]
             - Only comment on files shown by `gh pr diff --name-only`. Skip files unrelated to this PR.
             - Before posting, read `.claude_pr_threads.jsonl` (inline review threads, one per line: isResolved, isOutdated, path, line, comments[]) and `.claude_pr_toplevel.jsonl` (top-level PR comments). Skip an issue if any of these are true for a matching prior thread (same path + same root cause): `isResolved: true` (human closed it), `isOutdated: true` (code moved — raise fresh only if still wrong), a human has replied (they've engaged; leave it alone), or the referenced code no longer exists or is already fixed.
 
@@ -109,4 +110,4 @@ jobs:
             Use `mcp__github_inline_comment__create_inline_comment` to highlight specific code issues.
             Only post GitHub comments - don't submit review text as messages.
           claude_args: |
-            --allowedTools "Read,mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
+            --allowedTools "Read,mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh issue list:*),Bash(gh pr list:*)"

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -46,6 +46,18 @@ jobs:
           gh api --method POST -H "Accept: application/vnd.github+json" \
             "/repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions" \
             -f content='eyes' || true
+      - name: Dump prior bot review comments
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN || github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+        run: |
+          {
+            gh api --paginate "/repos/${{ github.repository }}/pulls/$PR_NUMBER/comments" \
+              --jq '.[] | select(.user.type=="Bot") | {kind:"inline", path, line, body}'
+            gh api --paginate "/repos/${{ github.repository }}/issues/$PR_NUMBER/comments" \
+              --jq '.[] | select(.user.type=="Bot") | {kind:"toplevel", body}'
+          } > .claude_prior_comments.jsonl || true
+          echo "prior comments: $(wc -l < .claude_prior_comments.jsonl || echo 0)"
       - uses: anthropics/claude-code-action@905d4eb99ab3d43143d74fb0dcae537f29ac330a # v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -66,6 +78,7 @@ jobs:
             - Get familiar with the codebase by reading ./AGENTS.md in the repo root.
             - You are called on new commits to the PR, so focus on the latest changes and how they integrate with the existing code. Avoid redundant comments on unchanged code.
             - Cap at 5 comments per review. Pick the most important. Skip anything already caught by ruff/pre-commit.
+            - Before posting, read `.claude_prior_comments.jsonl` (one JSON object per line) — comments you already posted on this PR. Do not repost the same issue (same path and same root cause). If the code referenced by a prior comment no longer exists or is already fixed, skip instead of re-raising.
 
             Output format — ultra-terse, one line per issue:
             - Drop articles (a/an/the), filler words, pleasantries, and preamble.
@@ -77,4 +90,4 @@ jobs:
             Use `mcp__github_inline_comment__create_inline_comment` to highlight specific code issues.
             Only post GitHub comments - don't submit review text as messages.
           claude_args: |
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
+            --allowedTools "Read,mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -6,8 +6,10 @@ on:
         required: false
   pull_request:
     types: [opened, synchronize, reopened]
+  issue_comment:
+    types: [created]
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}-claude-pr-review
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number }}-claude-pr-review
   cancel-in-progress: true
 permissions:
   contents: read
@@ -16,7 +18,13 @@ permissions:
   id-token: write
 jobs:
   review:
-    if: github.event_name != 'pull_request' || github.event.pull_request.user.login != 'dependabot[bot]'
+    if: >-
+      (github.event_name == 'pull_request' &&
+       github.event.action != 'synchronize' &&
+       github.event.pull_request.user.login != 'dependabot[bot]') ||
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request != null &&
+       contains(github.event.comment.body, '/claude-api review'))
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -25,13 +33,25 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          fetch-depth: 1
+          fetch-depth: 0
+      - name: Checkout PR head
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN || github.token }}
+        run: gh pr checkout "${{ github.event.pull_request.number || github.event.issue.number }}"
+      - name: React to trigger comment
+        if: github.event_name == 'issue_comment'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN || github.token }}
+        run: |
+          gh api --method POST -H "Accept: application/vnd.github+json" \
+            "/repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions" \
+            -f content='eyes' || true
       - uses: anthropics/claude-code-action@905d4eb99ab3d43143d74fb0dcae537f29ac330a # v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           prompt: |
             REPO: ${{ github.repository }}
-            PR NUMBER: ${{ github.event.pull_request.number }}
+            PR NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
 
             Please review this pull request with a focus on:
             - Code quality and best practices

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ PDK repos reference these workflows via `workflow_call`. Create thin wrapper wor
 |----------|------|-------------|
 | `test_code.yml` | pre-commit, test_code, test_gfp | Pre-commit (canonical config), pytest, GFP validation |
 | `pages.yml` | build-docs, deploy-docs | Sphinx docs build and GitHub Pages deployment |
-| `claude-pr-review.yml` | review | AI code review via Claude Sonnet 4 on PRs |
+| `claude-pr-review.yml` | review | AI code review via Claude Sonnet 4. Runs once on PR open/reopen; re-run on demand by commenting `/claude-api review` |
 | `release-drafter.yml` | update_release_draft | Auto-drafted release notes with Claude-curated changelog |
 | `drc.yml` | drc | Design Rule Check with GFP and badge generation |
 | `issue.yml` | add-label | Auto-labels issues with "pdk" tag |
@@ -200,7 +200,7 @@ Reference configuration files are provided in `templates/` for onboarding new PD
 | `.pre-commit-config.yaml` | Canonical pre-commit config (PDK hooks + third-party tools with centralized versions) |
 | `.github/workflows/test_code.yml` | Pre-commit, pytest, and GFP validation |
 | `.github/workflows/pages.yml` | Sphinx docs build and GitHub Pages deployment |
-| `.github/workflows/claude-pr-review.yml` | AI code review via Claude |
+| `.github/workflows/claude-pr-review.yml` | AI code review via Claude — runs once on PR open/reopen; re-run on demand with `/claude-api review` comment |
 | `.github/workflows/release-drafter.yml` | Semantic versioning and Claude-curated release notes |
 | `.github/workflows/drc.yml` | Design Rule Check via GFP |
 | `.github/workflows/issue.yml` | Auto-label PDK issues |

--- a/templates/README.md
+++ b/templates/README.md
@@ -10,7 +10,7 @@ Minimal wrappers — each just calls the upstream reusable workflow with `secret
 |------|---------|
 | `.github/workflows/test_code.yml` | Pre-commit, pytest, GFP validation |
 | `.github/workflows/pages.yml` | Sphinx docs build + GitHub Pages |
-| `.github/workflows/claude-pr-review.yml` | AI code review via Claude |
+| `.github/workflows/claude-pr-review.yml` | AI code review via Claude — runs once on PR open/reopen; re-run on demand with `/claude-api review` comment |
 | `.github/workflows/release-drafter.yml` | Semantic versioning + Claude-curated release notes |
 | `.github/workflows/drc.yml` | Design Rule Check via GFP |
 | `.github/workflows/issue.yml` | Auto-label PDK issues |


### PR DESCRIPTION
Closes #108

## Summary
- **Opt-in re-runs only.** Auto-review on PR `opened`/`reopened`. `synchronize` events no longer trigger the bot (template still fires but reusable workflow short-circuits via `if:` guard, so no template drift to propagate). Re-run on demand by commenting `/claude-api review` on the PR.
- **Dedup against prior PR discussion.** New step dumps all review threads (via GraphQL: `isResolved`, `isOutdated`, path, line, authors) and top-level PR comments to JSONL files. Prompt rule: skip an issue if the matching prior thread is resolved, outdated, human-replied, or refers to code that no longer exists / is already fixed.
- **Scope to PR diff.** One-line prompt rule: only comment on files in `gh pr diff --name-only`.
- **Severity calibration.** 🔴 reserved for merge-blockers (CI breaks, wrong output/behavior, security). Tie-breaker bias: if unsure, use 🟡. Hard cap: max one 🔴 per review.
- **Output cap.** Max 5 comments per review. Skip anything already caught by ruff/pre-commit.
- **UX.** 👀 reaction on the trigger comment so humans know the bot picked it up.
- Docs updated in `README.md`, `templates/README.md`, `.github/workflows/README.md`.

Template file (`templates/.github/workflows/claude-pr-review.yml`) intentionally unchanged — all behavior lives upstream so downstream PDK repos inherit without a drift-fix PR.

## Test plan
- [ ] Open a fresh PR → bot posts one review on `opened`
- [ ] Push a new commit → no new review (verify `synchronize` is ignored)
- [ ] Comment `/claude-api review` → bot re-reviews, adds 👀 reaction
- [ ] Verify the new review does not repeat prior comments
- [ ] Resolve a prior thread manually, re-trigger → bot skips the resolved issue
- [ ] Reply to a prior bot comment as a human, re-trigger → bot skips that issue
- [ ] Push a merge commit (`Merge branch 'main' into ...`) → bot does not re-review
- [ ] Check that no inline comment lands on a file outside the PR diff
- [ ] Confirm at most one 🔴 per review, ≤5 comments total