### PR TITLE
Exclude cells_no_model_expected from model coverage

### DIFF
--- a/.github/workflows/model_coverage.yml
+++ b/.github/workflows/model_coverage.yml
@@ -37,8 +37,10 @@ jobs:
           pdk.activate()
           cells = pdk.cells
           models = getattr(pdk, "models", {}) or {}
-          total = len(cells)
-          with_model = len(set(cells) & set(models))
+          skip = set(cfg.get("tool", {}).get("gdsfactoryplus", {}).get("pdk", {}).get("cells_no_model_expected", []))
+          relevant_cells = set(cells) - skip
+          total = len(relevant_cells)
+          with_model = len(relevant_cells & set(models))
           pct = (with_model / total * 100) if total else 0
 
           summary = os.environ.get("GITHUB_STEP_SUMMARY", "/dev/null")

--- a/.github/workflows/update_badges.yml
+++ b/.github/workflows/update_badges.yml
@@ -55,7 +55,7 @@ jobs:
         run: |
           mkdir -p badges
           uv run python - <<'PYEOF'
-          import importlib, os, subprocess, xml.etree.ElementTree as ET
+          import importlib, os, subprocess, tomllib, xml.etree.ElementTree as ET
           from pathlib import Path
 
           SVG_TEMPLATE = """\
@@ -104,13 +104,17 @@ jobs:
           # --- Model Coverage ---
           pdk_module = os.environ.get("PDK_MODULE", "")
           try:
+              with open("pyproject.toml", "rb") as f:
+                  cfg = tomllib.load(f)
+              skip = set(cfg.get("tool", {}).get("gdsfactoryplus", {}).get("pdk", {}).get("cells_no_model_expected", []))
               mod = importlib.import_module(pdk_module)
               pdk = mod.PDK
               pdk.activate()
               cells = pdk.cells
               models = getattr(pdk, "models", {}) or {}
-              total = len(cells)
-              with_model = len(set(cells) & set(models))
+              relevant_cells = set(cells) - skip
+              total = len(relevant_cells)
+              with_model = len(relevant_cells & set(models))
               model_pct = (with_model / total * 100) if total else 0
           except Exception as e:
               print(f"  model coverage error: {e}")


### PR DESCRIPTION
## Summary

- Reads `cells_no_model_expected` list from `pyproject.toml` under `[tool.gdsfactoryplus.pdk]`
- Subtracts those cells from the model coverage denominator in both `model_coverage.yml` and `update_badges.yml`
- Backwards compatible: if the key is absent, behavior is unchanged (empty list)

Companion PR: https://github.com/doplaydo/PH18/pull/452

## Test plan
- [ ] Verify coverage calculation excludes listed cells
- [ ] Verify badge generation still works for repos without `cells_no_model_expected`