### PR TITLE
Add retention-days input to pages workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,6 +1,12 @@
 name: build docs
 on:
   workflow_call:
+    inputs:
+      retention-days:
+        description: 'Number of days to retain the pages artifact'
+        required: false
+        type: number
+        default: 1
     secrets:
       GFP_API_KEY:
         required: false
@@ -35,3 +41,4 @@ jobs:
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5
         with:
           path: "./docs/_build/html/"
+          retention-days: ${{ inputs.retention-days }}


### PR DESCRIPTION
## Summary
- Adds a `retention-days` input to the reusable pages workflow (defaults to 1 day)
- Passes it through to `actions/upload-pages-artifact`
- Prevents GitHub Actions artifact storage quota from being hit by frequent doc builds

## Test plan
- [x] Verify the workflow YAML is valid
- [ ] Caller repos can override retention with `with: { retention-days: N }`