### PR TITLE
Fix build_cell all_cells producing empty GDS

### DIFF
--- a/templates/build_cell.py
+++ b/templates/build_cell.py
@@ -24,7 +24,7 @@ if cell_name == "all_cells":
     for name, func in sorted(pdk.cells.items()):
         # Skip cells from installed packages (not PDK-owned)
         try:
-            src = inspect.getfile(func)
+            src = inspect.getfile(inspect.unwrap(func))
         except TypeError:
             continue
         if ".venv" in src or "site-packages" in src:


### PR DESCRIPTION
## Summary
- `inspect.getfile(func)` on `@gf.cell`-decorated functions returns the wrapper location (`kfactory/layout.py` in site-packages), not the actual cell source
- This causes the `.venv`/`site-packages` filter to skip every cell, producing an empty GDS
- Fix: use `inspect.unwrap(func)` to follow the `__wrapped__` chain before calling `inspect.getfile()`

## Test plan
- [x] Verified in 45SPCLO: `uv run python build_cell.py all_cells` now produces a 143 MB GDS instead of an empty file



fixes emtpy all_cells GDS file in 45SPCLO

<img width="779" height="533" alt="image" src="https://github.com/user-attachments/assets/41cbf99d-df36-4e4c-91e1-a3e776b30f33" />

