### PR TITLE
Add default skip list for model coverage

### DIFF
--- a/.github/workflows/model_coverage.yml
+++ b/.github/workflows/model_coverage.yml
@@ -37,7 +37,11 @@ jobs:
           pdk.activate()
           cells = pdk.cells
           models = getattr(pdk, "models", {}) or {}
-          skip = set(cfg.get("tool", {}).get("gdsfactoryplus", {}).get("pdk", {}).get("cells_no_model_expected", []))
+          default_skip = set()
+          default_skip_prefixes = ("add_fiber", "die", "import_gds", "load", "mzi", "mzm", "pack", "pad", "rectangle", "ring", "spiral", "TEMPLATE", "via", "wire")
+          skip = default_skip | set(cfg.get("tool", {}).get("gdsfactoryplus", {}).get("pdk", {}).get("cells_no_model_expected", []))
+          default_skip_contains = ("bondpad", "frame", "metal")
+          skip |= {c for c in cells if c.startswith(default_skip_prefixes) or any(s in c for s in default_skip_contains)}
           relevant_cells = set(cells) - skip
           total = len(relevant_cells)
           with_model = len(relevant_cells & set(models))


### PR DESCRIPTION
## Summary
- Skip cells that typically don't have models by default in the model coverage workflow
- **Prefix match**: `add_fiber`, `die`, `import_gds`, `load`, `mzi`, `mzm`, `pack`, `pad`, `rectangle`, `ring`, `spiral`, `TEMPLATE`, `via`, `wire`
- **Substring match**: `bondpad`, `frame`, `metal`
- Per-PDK overrides via `cells_no_model_expected` in pyproject.toml still apply

## Test plan
- [ ] Run model coverage workflow on a PDK repo and verify skipped cells appear in the "Cells no model expected" section