### PR TITLE
fix: skip samples/ cells in all_cells build

### DIFF
--- a/scripts/build_cell.py
+++ b/scripts/build_cell.py
@@ -2,8 +2,10 @@
 
 When cell_name is "all_cells", builds every PDK-owned cell that can be
 instantiated with default arguments and packs them into a single GDS.
-Cells from installed packages (site-packages / .venv) and cells that
-require positional arguments are skipped automatically.
+Cells from installed packages (site-packages / .venv), cells located
+under a ``samples/`` directory (demo/tapeout cells that re-use BB cells
+and would cause cellname collisions), and cells that require positional
+arguments are skipped automatically.
 """
 
 import inspect
@@ -28,6 +30,13 @@ if cell_name == "all_cells":
         except TypeError:
             continue
         if ".venv" in src or "site-packages" in src:
+            continue
+
+        # Skip demo/tapeout cells under a samples/ directory: they re-use BB
+        # cells already registered as top-level PDK cells, which would cause
+        # cellname collisions when packed together.
+        if "/samples/" in src or src.endswith("/samples"):
+            print(f"Skipping {name}: in samples/")
             continue
 
         # Skip cells that require positional arguments


### PR DESCRIPTION
## Problem

Downstream PDK DRC CI fails on `all_cells` build with klayout `topological_sort` errors and `RuntimeError: cell name used for more than one cell`.

## Root cause

Demo/tapeout cells in `<pdk>/samples/` (e.g. `golden`, `golden_an800`) are registered as top-level PDK cells via `register_cells()`. They instantiate BB cells like `AN800BB_MMI1x2_symmetric_C` internally. When `all_cells` adds the same BB cells directly AND the samples that contain them, klayout sees duplicate cell names and fails.

This was latent: before `inspect.unwrap(func)` was added, `inspect.getfile(func)` on decorated cells returned the kfactory decorator file (in site-packages), so the `.venv`/`site-packages` filter excluded everything and `all_cells` was silently empty → DRC trivially passed.

## Fix

Skip cells whose source file is under a `samples/` directory.

## Repro

- doplaydo/ligentec-an800 main post-#420: https://github.com/doplaydo/ligentec-an800/actions/runs/24838839523
- doplaydo/ligentec-an350 main post-#227: same symptom

🤖 Generated with [Claude Code](https://claude.com/claude-code)