### PR TITLE
fix: delegate all_cells to PDK-registered cell

### DIFF
--- a/scripts/build_cell.py
+++ b/scripts/build_cell.py
@@ -1,14 +1,5 @@
-"""Build a cell and write it to build/gds/<cell_name>.gds.
+"""Build a cell and write it to build/gds/<cell_name>.gds."""
 
-When cell_name is "all_cells", builds every PDK-owned cell that can be
-instantiated with default arguments and packs them into a single GDS.
-Cells from installed packages (site-packages / .venv), cells located
-under a ``samples/`` directory (demo/tapeout cells that re-use BB cells
-and would cause cellname collisions), and cells that require positional
-arguments are skipped automatically.
-"""
-
-import inspect
 import sys
 from pathlib import Path
 
@@ -19,43 +10,5 @@ Path("build/gds").mkdir(parents=True, exist_ok=True)
 register_cells()
 pdk = get_pdk()
 
-if cell_name == "all_cells":
-    import gdsfactory as gf
-
-    c = gf.Component("all_cells")
-    for name, func in sorted(pdk.cells.items()):
-        # Skip cells from installed packages (not PDK-owned)
-        try:
-            src = inspect.getfile(inspect.unwrap(func))
-        except TypeError:
-            continue
-        if ".venv" in src or "site-packages" in src:
-            continue
-
-        # Skip demo/tapeout cells under a samples/ directory: they re-use BB
-        # cells already registered as top-level PDK cells, which would cause
-        # cellname collisions when packed together.
-        if "/samples/" in src or src.endswith("/samples"):
-            print(f"Skipping {name}: in samples/")
-            continue
-
-        # Skip cells that require positional arguments
-        sig = inspect.signature(func)
-        required = [
-            p
-            for p in sig.parameters.values()
-            if p.default is inspect.Parameter.empty
-            and p.kind not in (p.VAR_POSITIONAL, p.VAR_KEYWORD)
-        ]
-        if required:
-            print(f"Skipping {name}: requires arguments {[p.name for p in required]}")
-            continue
-
-        try:
-            c.add_ref(func())
-        except Exception as e:  # noqa: BLE001
-            print(f"Error instantiating cell {name}: {e}")
-    c.write_gds(f"build/gds/{cell_name}.gds")
-else:
-    c = pdk.cells[cell_name]()
-    c.write_gds(f"build/gds/{cell_name}.gds")
+c = pdk.cells[cell_name]()
+c.write_gds(f"build/gds/{cell_name}.gds")


### PR DESCRIPTION
## Problem

Follow-up to #144. Even with samples/ filtered out, `build_cell.py` for `all_cells` stacks every cell at (0,0) because the special-case loop does `c.add_ref(func())` with no placement.

Downstream PDKs (e.g. ligentec-an800, ligentec-an350) already define an `all_cells` cell in `samples/all_cells.py` that uses `gf.pack(cells, spacing=20)` and handles its own exclusions (goldens, etc.).

## Fix

Drop the special-case for `"all_cells"`. Let it fall through to `pdk.cells[cell_name]()` like any other cell name — that invokes the PDK's own `all_cells` cell, which already does the right thing.

## Effect

- Downstream PDKs with an `all_cells` cell work correctly (packed, non-overlapping, properly filtered)
- Downstream PDKs without one would raise `KeyError` — but they already had to register one for the DRC workflow to target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)