### PR TITLE
Add daily schedule to update_badges workflow

### DIFF
--- a/.github/workflows/update_badges.yml
+++ b/.github/workflows/update_badges.yml
@@ -1,5 +1,7 @@
 name: Update Badges
 on:
+  schedule:
+    - cron: "0 0 * * *"
   workflow_call:
     secrets:
       GFP_API_KEY:


### PR DESCRIPTION
## Summary
- Adds a daily cron schedule (`0 0 * * *` — midnight UTC) to the `update_badges` reusable workflow so badges refresh automatically every day, not only when called by other workflows.

## Test plan
- [ ] Verify workflow syntax is valid via Actions tab
- [ ] Confirm badges update on next scheduled run